### PR TITLE
Fix backward propagation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/observations/ObsCodes.txt
+++ b/src/observations/ObsCodes.txt
@@ -2317,6 +2317,7 @@ X50 303.824190.821025-0.568999Observatorio Astronomico de Montevideo
 X57 305.406260.903659-0.426885Polo Astronomico CMF,Foz do Iguacu
 X60 306.425560.895232-0.444317Guaraciaba Observatory
 X70 308.433220.931623-0.362375Observatorio OATU, Tupi Paulista
+X72 308.878890.868775-0.493560Waccobs, Sao Leopoldo
 X74 309.150600.929870-0.366840Observatorio Campo dos Amarais
 X77 309.924750.900184-0.434346Centro Astron. Nevoeiro, Antonio Olinto
 X87 312.088900.962180-0.272100Dogsheaven Observatory, Brasilia

--- a/src/observations/jpl_eph.jl
+++ b/src/observations/jpl_eph.jl
@@ -119,25 +119,24 @@ dtt_tdb(et) = getposvel(1000000001, 1000000000, cte(et))[4] # units: seconds/sec
 
 # Load Solar System 2000-2100 ephemeris
 const sseph_artifact_path = joinpath(artifact"sseph_p100", "sseph343ast016_p100y_et.jld2")
-const sseph = JLD2.load(sseph_artifact_path, "ss16ast_eph")
-const ttmtdb = TaylorInterpolant(sseph.t0, sseph.t, sseph.x[:,end])
+const sseph::TaylorInterpolant{Float64, Float64, 2} = JLD2.load(sseph_artifact_path, "ss16ast_eph")
+const ttmtdb::TaylorInterpolant{Float64, Float64, 1} = TaylorInterpolant(sseph.t0, sseph.t, sseph.x[:,end])
 
 @doc raw"""
-    loadpeeph(et::Union{Nothing, Real} = nothing)
+    loadpeeph()
+    loadpeeph(et::Real)
     loadpeeph(et_0::Real, et_f::Real)
 
 Load Solar System ephemeris produced by `PlanetaryEphemeris.jl` in timerange `[0, et]` (`[et_0, et_f]`) where `et` must have units
-of ephemeris seconds since J2000.
+of ephemeris seconds since J2000. If no `et` is given, return the full (100 years) integration. 
 
 **Caution**: running this function for the first time will download the `sseph_p100` artifact (∼556 MB) which can take several minutes.
 """
-function loadpeeph(et::Union{Nothing, Real} = nothing)
-    if isnothing(et)
-        return sseph
-    else
-        i = searchsortedfirst(sseph.t, et)
-        return TaylorInterpolant(sseph.t0, sseph.t[1:i], sseph.x[1:i-1, :])
-    end
+loadpeeph()::TaylorInterpolant{Float64, Float64, 2} = sseph
+
+function loadpeeph(et::Real)
+    i = searchsortedfirst(sseph.t, et)
+    return TaylorInterpolant(sseph.t0, sseph.t[1:i], sseph.x[1:i-1, :])
 end
 
 function loadpeeph(et_0::Real, et_f::Real)

--- a/src/observations/jpl_eph.jl
+++ b/src/observations/jpl_eph.jl
@@ -124,19 +124,27 @@ const ttmtdb = TaylorInterpolant(sseph.t0, sseph.t, sseph.x[:,end])
 
 @doc raw"""
     loadpeeph(et::Union{Nothing, Real} = nothing)
+    loadpeeph(et_0::Real, et_f::Real)
 
-Load Solar System ephemeris produced by `PlanetaryEphemeris.jl` from Jan 1st 2000 up to `et > 0` [ephemeris seconds since J2000].
+Load Solar System ephemeris produced by `PlanetaryEphemeris.jl` in timerange `[0, et]` (`[et_0, et_f]`) where `et` must have units
+of ephemeris seconds since J2000.
 
-**Caution**: running this function for the first time will download the `sseph_p100` artifact (∼554 MB) which can take several minutes.
+**Caution**: running this function for the first time will download the `sseph_p100` artifact (∼556 MB) which can take several minutes.
 """
 function loadpeeph(et::Union{Nothing, Real} = nothing)
     if isnothing(et)
         return sseph
     else
-        idxs = findall(x -> x <= et, sseph.t)
-        return TaylorInterpolant(sseph.t0, sseph.t[idxs], sseph.x[idxs[1:end-1], :])
+        i = searchsortedfirst(sseph.t, et)
+        return TaylorInterpolant(sseph.t0, sseph.t[1:i], sseph.x[1:i-1, :])
     end
 end
+
+function loadpeeph(et_0::Real, et_f::Real)
+    i_0 = searchsortedlast(sseph.t, et_0)
+    i_f = searchsortedfirst(sseph.t, et_f)
+    return TaylorInterpolant(sseph.t0, sseph.t[i_0:i_f], sseph.x[i_0:i_f-1, :])
+end 
 
 function bwdfwdeph(et::Union{T,TaylorN{T}},
         bwd::TaylorInterpolant{T,U,2},

--- a/src/propagation/propagation.jl
+++ b/src/propagation/propagation.jl
@@ -266,9 +266,9 @@ function propagate_params(jd0::T, ss16asteph_et::TaylorInterpolant, q0::Vector{U
 end
 
 @doc raw"""
-    propagate(dynamics::D, maxsteps::Int, jd0::T, tspan::T, ss16asteph_et::TaylorInterpolant,
-              q0::Vector{U}, ::$V_dense; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order,
-              abstol::T = abstol, parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
+    propagate(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}, ::$V_dense; 
+              μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol, 
+              parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
 
 Integrate the orbit of a NEO via the Taylor method.
 
@@ -278,7 +278,6 @@ Integrate the orbit of a NEO via the Taylor method.
 - `maxsteps::Int`: maximum number of steps for the integration.
 - `jd0::T`: initial Julian date.
 - `tspan::T`: time span of the integration [in years].
-- `ss16asteph_et::TaylorInterpolant`: solar system ephemeris.
 - `q0::Vector{U}`: vector of initial conditions.
 - `Val(true/false)`: whether to output the Taylor polynomials generated at each time step (`true`) or not.
 - `μ_ast::Vector`: vector of gravitational parameters.
@@ -288,10 +287,9 @@ Integrate the orbit of a NEO via the Taylor method.
 """ propagate
 
 @doc raw"""
-    propagate_root(dynamics::D, maxsteps::Int, jd0::T, tspan::T, ss16asteph_et::TaylorInterpolant,
-                   q0::Vector{U}, ::$V_dense; parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10,
-                   nrabstol::T = eps(T), μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order,
-                   abstol::T = abstol) where {T <: Real, U <: Number, D}
+    propagate_root(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}, ::$V_dense; parse_eqs::Bool = true, 
+                   eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T = eps(T), μ_ast::Vector = μ_ast343_DE430[1:end],
+                   order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
 
 Integrate the orbit of a NEO via the Taylor method while finding the zeros of `rvelea`.
 
@@ -301,7 +299,6 @@ Integrate the orbit of a NEO via the Taylor method while finding the zeros of `r
 - `maxsteps::Int`: maximum number of steps for the integration.
 - `jd0::T`: initial Julian date.
 - `tspan::T`: time span of the integration [in years].
-- `ss16asteph_et::TaylorInterpolant`: solar system ephemeris.
 - `q0::Vector{U}`: vector of initial conditions.
 - `Val(true/false)`: whether to output the Taylor polynomials generated at each time step (`true`) or not.
 - `parse_eqs::Bool`: whether to use the specialized method of `jetcoeffs` (`true`) or not.
@@ -317,10 +314,11 @@ for V_dense in V_true_false
 
     @eval begin
 
-        function propagate(dynamics::D, maxsteps::Int, jd0::T, tspan::T, sseph::TaylorInterpolant, q0::Vector{U},
-                           ::$V_dense; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol,
+        function propagate(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}, ::$V_dense; 
+                           μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol,
                            parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
 
+            # Load Solar System ephemeris 
             _sseph = loadpeeph(julian2etsecs.(minmax(jd0, jd0+tspan*yr))...)
 
             # Parameters for neosinteg
@@ -339,35 +337,36 @@ for V_dense in V_true_false
 
         end
 
-        function propagate(dynamics::D, maxsteps::Int, jd0::T1, tspan::T2, sseph::TaylorInterpolant, q0::Vector{U},
-                           ::$V_dense; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T3 = abstol,
+        function propagate(dynamics::D, maxsteps::Int, jd0::T1, tspan::T2, q0::Vector{U}, ::$V_dense; 
+                           μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T3 = abstol,
                            parse_eqs::Bool = true) where {T1, T2, T3 <: Real, U <: Number, D}
 
             _jd0, _tspan, _abstol = promote(jd0, tspan, abstol)
 
-            return propagate(dynamics, maxsteps, _jd0, _tspan, sseph, q0, $V_dense(); μ_ast = μ_ast, order = order,
+            return propagate(dynamics, maxsteps, _jd0, _tspan, q0, $V_dense(); μ_ast = μ_ast, order = order,
                              abstol = _abstol, parse_eqs = parse_eqs)
         end
 
-        function propagate(dynamics::D, maxsteps::Int, jd0::T, nyears_bwd::T, nyears_fwd::T, sseph::TaylorInterpolant,
-                           q0::Vector{U}, ::$V_dense; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol,
+        function propagate(dynamics::D, maxsteps::Int, jd0::T, nyears_bwd::T, nyears_fwd::T, q0::Vector{U}, ::$V_dense; 
+                           μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol,
                            parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
 
             # Backward integration
-            bwd = propagate(dynamics, maxsteps, jd0, nyears_bwd, sseph, q0, $V_dense(); μ_ast = μ_ast, order = order,
+            bwd = propagate(dynamics, maxsteps, jd0, nyears_bwd, q0, $V_dense(); μ_ast = μ_ast, order = order,
                             abstol = abstol, parse_eqs = parse_eqs)
             # Forward integration
-            fwd = propagate(dynamics, maxsteps, jd0, nyears_fwd, sseph, q0, $V_dense(); μ_ast = μ_ast, order = order,
+            fwd = propagate(dynamics, maxsteps, jd0, nyears_fwd, q0, $V_dense(); μ_ast = μ_ast, order = order,
                             abstol = abstol, parse_eqs = parse_eqs)
 
             return bwd, fwd
 
         end
 
-        function propagate_root(dynamics::D, maxsteps::Int, jd0::T, tspan::T, sseph::TaylorInterpolant, q0::Vector{U},
-                                ::$V_dense; parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T = eps(T),
-                                μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
+        function propagate_root(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}, ::$V_dense; parse_eqs::Bool = true, 
+                                eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T = eps(T), μ_ast::Vector = μ_ast343_DE430[1:end],
+                                order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
 
+            # Load Solar System ephemeris 
             _sseph = loadpeeph(julian2etsecs.(minmax(jd0, jd0+tspan*yr))...)
 
             # Parameters for neosinteg
@@ -385,27 +384,27 @@ for V_dense in V_true_false
 
         end
 
-        function propagate_root(dynamics::D, maxsteps::Int, jd0::T1, tspan::T2, sseph::TaylorInterpolant, q0::Vector{U},
-                                ::$V_dense; parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T3 = eps(T),
-                                μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T4 = abstol) where {T1, T2, T3, T4 <: Real, U <: Number, D}
+        function propagate_root(dynamics::D, maxsteps::Int, jd0::T1, tspan::T2, q0::Vector{U}, ::$V_dense; parse_eqs::Bool = true, 
+                                eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T3 = eps(T), μ_ast::Vector = μ_ast343_DE430[1:end],
+                                order::Int = order, abstol::T4 = abstol) where {T1, T2, T3, T4 <: Real, U <: Number, D}
 
             _jd0, _tspan, _nrabstol, _abstol = promote(jd0, tspan, nrabstol, abstol)
 
-            return propagate_root(dynamics, maxsteps, _jd0, _tspan, sseph, q0, $V_dense(); parse_eqs = parse_eqs,
+            return propagate_root(dynamics, maxsteps, _jd0, _tspan, q0, $V_dense(); parse_eqs = parse_eqs,
                                   eventorder = eventorder, newtoniter = newtoniter, nrabstol = _nrabstol, μ_ast = μ_ast,
                                   order = order, abstol = _abstol)
         end
 
-        function propagate_root(dynamics::D, maxsteps::Int, jd0::T, nyears_bwd::T, nyears_fwd::T, sseph::TaylorInterpolant,
-                                q0::Vector{U}, ::$V_dense; parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10,
-                                nrabstol::T = eps(T), μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
+        function propagate_root(dynamics::D, maxsteps::Int, jd0::T, nyears_bwd::T, nyears_fwd::T, q0::Vector{U}, ::$V_dense; 
+                                parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T = eps(T), 
+                                μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
 
             # Backward integration
-            bwd, tvS_bwd, xvS_bwd, gvS_bwd = propagate_root(dynamics, maxsteps, jd0, nyears_bwd, sseph, q0, $V_dense(); parse_eqs = parse_eqs,
+            bwd, tvS_bwd, xvS_bwd, gvS_bwd = propagate_root(dynamics, maxsteps, jd0, nyears_bwd, q0, $V_dense(); parse_eqs = parse_eqs,
                                                             eventorder = eventorder, newtoniter = newtoniter, nrabstol = nrabstol,
                                                             μ_ast = μ_ast, order = order, abstol = abstol)
             # Forward integration
-            fwd, tvS_fwd, xvS_fwd, gvS_fwd = propagate_root(dynamics, maxsteps, jd0, nyears_fwd, sseph, q0, $V_dense(); parse_eqs = parse_eqs,
+            fwd, tvS_fwd, xvS_fwd, gvS_fwd = propagate_root(dynamics, maxsteps, jd0, nyears_fwd, q0, $V_dense(); parse_eqs = parse_eqs,
                                                             eventorder = eventorder, newtoniter = newtoniter, nrabstol = nrabstol,
                                                             μ_ast = μ_ast, order = order, abstol = abstol)
 
@@ -417,9 +416,8 @@ for V_dense in V_true_false
 end
 
 @doc raw"""
-    propagate_lyap(dynamics::D, maxsteps::Int, jd0::T, tspan::T, ss16asteph_et::TaylorInterpolant,
-                   q0::Vector{U}; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order,
-                   abstol::T = abstol, parse_eqs::Bool = true) where {T <: Real, U <: Number}
+    propagate_lyap(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}; μ_ast::Vector = μ_ast343_DE430[1:end],
+                   order::Int = order, abstol::T = abstol, parse_eqs::Bool = true) where {T <: Real, U <: Number}
 
 Compute the Lyapunov spectrum of a NEO.
 
@@ -429,19 +427,20 @@ Compute the Lyapunov spectrum of a NEO.
 - `maxsteps::Int`: maximum number of steps for the integration.
 - `jd0::T`: initial Julian date.
 - `tspan::T`: time span of the integration [in Julian days].
-- `ss16asteph_et::TaylorInterpolant`: solar system ephemeris.
 - `q0::Vector{U}`: vector of initial conditions.
 - `μ_ast::Vector`: vector of gravitational parameters.
 - `order::Int=order`: order of the Taylor expansions to be used in the integration.
 - `abstol::T`: absolute tolerance.
 - `parse_eqs::Bool`: whether to use the specialized method of `jetcoeffs` (`true`) or not.
 """ propagate_lyap
-function propagate_lyap(dynamics::D, maxsteps::Int, jd0::T, tspan::T, ss16asteph_et::TaylorInterpolant,
-                        q0::Vector{U}; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order,
-                        abstol::T = abstol, parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
+function propagate_lyap(dynamics::D, maxsteps::Int, jd0::T, tspan::T, q0::Vector{U}; μ_ast::Vector = μ_ast343_DE430[1:end], 
+                        order::Int = order, abstol::T = abstol, parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
+
+    # Load Solar System ephemeris 
+    _sseph = loadpeeph(julian2etsecs.(minmax(jd0, jd0+tspan*yr))...)
 
     # Parameters for apophisinteg
-    _q0, _t0, _eph, _params = propagate_params(jd0, ss16asteph_et, q0; μ_ast = μ_ast, order = order, abstol = abstol)
+    _q0, _t0, _eph, _params = propagate_params(jd0, _sseph, q0; μ_ast = μ_ast, order = order, abstol = abstol)
 
     # Final time of integration (days)
     _tmax = _t0 + tspan*yr

--- a/src/propagation/propagation.jl
+++ b/src/propagation/propagation.jl
@@ -321,7 +321,7 @@ for V_dense in V_true_false
                            ::$V_dense; μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol,
                            parse_eqs::Bool = true) where {T <: Real, U <: Number, D}
 
-            _sseph = loadpeeph(julian2etsecs(jd0+tspan*yr))
+            _sseph = loadpeeph(julian2etsecs.(minmax(jd0, jd0+tspan*yr))...)
 
             # Parameters for neosinteg
             _q0, _t0, _eph, _params = propagate_params(jd0, _sseph, q0; μ_ast = μ_ast, order = order, abstol = abstol)
@@ -368,7 +368,7 @@ for V_dense in V_true_false
                                 ::$V_dense; parse_eqs::Bool = true, eventorder::Int = 0, newtoniter::Int = 10, nrabstol::T = eps(T),
                                 μ_ast::Vector = μ_ast343_DE430[1:end], order::Int = order, abstol::T = abstol) where {T <: Real, U <: Number, D}
 
-            _sseph = loadpeeph(julian2etsecs(jd0+tspan*yr))
+            _sseph = loadpeeph(julian2etsecs.(minmax(jd0, jd0+tspan*yr))...)
 
             # Parameters for neosinteg
             _q0, _t0, _eph, _params = propagate_params(jd0, _sseph, q0; μ_ast = μ_ast, order = order, abstol = abstol)


### PR DESCRIPTION
Currently, backward propagation throws an error because this line:
https://github.com/PerezHz/NEOs.jl/blob/905a80e0c40640db0df0904726296d70c1ec2c0d/src/propagation/propagation.jl#LL324C1-L324C60
loads an incomplete time interval. This PR introduces a simple change to fix this. 