### PR TITLE
`RecipesBase` extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,12 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
+[weakdeps]
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[extensions]
+NEOsRecipesBaseExt = "RecipesBase"
+
 [compat]
 Artifacts = "1"
 AutoHashEquals = "0.2"
@@ -52,6 +58,7 @@ LsqFit = "0.15"
 PlanetaryEphemeris = "0.8"
 Printf = "1"
 Quadmath = "0.5"
+RecipesBase = "1"
 Roots = "2"
 SPICE = "0.2"
 SatelliteToolboxTransformations = "0.1"

--- a/examples/recipes.jl
+++ b/examples/recipes.jl
@@ -1,0 +1,38 @@
+# Example: plot NEOs' custom objects leveraging the recipes in
+# ext/NEOsRecipesBaseExt.jl
+using NEOs, Plots
+
+# Download optical astrometry of asteroid 2023 DW
+radec = fetch_radec_mpc("designation" => "2023 DW")
+
+# Orbit determination
+params = NEOParameters(bwdoffset = 0.007, fwdoffset = 0.007)
+sol = orbitdetermination(radec, params)
+
+# Plot optical residuals
+plot(sol.res, label = "", xlabel = "αcos(δ) [arcsec]", ylabel = "δ [arcsec]",
+     title = "2023 DW optical O-C residuals")
+
+# Plot asteroid's orbit (in barycentric cartesian coordinates)
+# N: number of points between t0 and tf (100 by default)
+# projection: which coordinates to plot, options are: :x, :y, :z, :xy,
+#             :xz, :yz and :xyz (default)
+t0, tf = sol.bwd.t0 + sol.bwd.t[end], sol.fwd.t0 + sol.fwd.t[end]
+plot(sol, t0, tf, N = 10_000, projection = :xyz, label = "2023 DW",
+     xlabel = "x [au]", ylabel = "y [au]", zlabel = "z [au]", color = :blue)
+
+# We can also visualize the orbits of the Sun and the Earth
+scatter!(params.eph_su, t0, tf, N = 10_000, projection = :xyz,
+         label = "Sun", color = :yellow)
+plot!(params.eph_ea, t0, tf, N = 10_000, projection = :xyz,
+      label = "Earth", color = :green)
+
+# Plot the boundary of an admissible region
+# N: number of points along the boundary (100 by default)
+# ρscale: horizontal axis scale, either :linear (default) or :log
+using NEOs: AdmissibleRegion
+A = AdmissibleRegion(sol.tracklets[1], params)
+plot(A, N = 10_000, ρscale = :log, label = "", xlabel = "log10(ρ) [au]",
+     ylabel = "v_ρ [au/day]", title = "2023 DW first tracklet AR",
+     c = :red, linewidth = 2)
+

--- a/ext/NEOsRecipesBaseExt.jl
+++ b/ext/NEOsRecipesBaseExt.jl
@@ -1,0 +1,21 @@
+module NEOsRecipesBaseExt
+
+using RecipesBase
+using NEOs: OpticalResidual, AdmissibleRegion, cte, ra, dec, boundary
+
+@recipe function f(res::AbstractVector{OpticalResidual{T, U}}) where {T <: Real, U <: Number}
+    seriestype --> :scatter
+    return cte.(ra.(res)), cte.(dec.(res))
+end
+
+@recipe function f(A::AdmissibleRegion{T}; N::Int = 100, ρscale::Symbol = :linear) where {T <: Real}
+    seriestype --> :path
+    ps = map(t -> boundary(A, t), LinRange(0, 3, N));
+    xs, ys = first.(ps), last.(ps)
+    if ρscale == :log
+        xs .= log10.(xs)
+    end
+    return xs, ys
+end
+
+end

--- a/ext/NEOsRecipesBaseExt.jl
+++ b/ext/NEOsRecipesBaseExt.jl
@@ -1,7 +1,8 @@
 module NEOsRecipesBaseExt
 
 using RecipesBase
-using NEOs: OpticalResidual, AdmissibleRegion, cte, ra, dec, boundary
+using PlanetaryEphemeris: TaylorInterpolant
+using NEOs: OpticalResidual, AdmissibleRegion, NEOSolution, cte, ra, dec, boundary
 
 @recipe function f(res::AbstractVector{OpticalResidual{T, U}}) where {T <: Real, U <: Number}
     seriestype --> :scatter
@@ -10,12 +11,39 @@ end
 
 @recipe function f(A::AdmissibleRegion{T}; N::Int = 100, ρscale::Symbol = :linear) where {T <: Real}
     seriestype --> :path
-    ps = map(t -> boundary(A, t), LinRange(0, 3, N));
+    ps = map(t -> boundary(A, t), LinRange(0, 3, N))
     xs, ys = first.(ps), last.(ps)
     if ρscale == :log
         xs .= log10.(xs)
     end
     return xs, ys
+end
+
+@recipe function f(sol::U, t0::T, tf::T; N::Int = 100,
+                   projection::Symbol = :xyz) where {T <: Real, U <: Union{TaylorInterpolant, NEOSolution}}
+    seriestype --> :path
+    ts = LinRange(t0, tf, N)
+    rvs = Matrix{T}(undef, 6, N)
+    for i in eachindex(ts)
+        rvs[:, i] .= cte.(sol(ts[i])[1:6])
+    end
+    xs, ys, zs = rvs[1, :], rvs[2, :], rvs[3, :]
+
+    if projection == :x
+        return xs
+    elseif projection == :y
+        return ys
+    elseif projection == :z
+        return zs
+    elseif projection == :xy
+        return xs, ys
+    elseif projection == :xz
+        return xs, zs
+    elseif projection == :yz
+        return ys, zs
+    elseif projection == :xyz
+        return xs, ys, zs
+    end
 end
 
 end


### PR DESCRIPTION
This PR introduces a `RecipesBase` extension with custom recipes to plot some of `NEOs`' native objects. So far, there are only two recipes: `AbstractVector{OpticalResidual}` and `AdmissibleRegion`, although suggestions are welcomed @lbenet @PerezHz .