### PR TITLE
WIP: Reject outliers following during orbital fit iterations

### DIFF
--- a/src/orbitdetermination/admissibleregion.jl
+++ b/src/orbitdetermination/admissibleregion.jl
@@ -308,7 +308,7 @@ function _georangerates(coeffs::Vector{T}, ρ::S) where {T, S <: Real}
     if d > 0
         return [-sqrt(arG(coeffs, ρ)), sqrt(arG(coeffs, ρ))]
     elseif d == 0
-        return zero(T) * arG(coeffs, ρ)
+        return zero(T) * [arG(coeffs, ρ)]
     else
         return Vector{T}(undef, 0)
     end

--- a/test/bplane.jl
+++ b/test/bplane.jl
@@ -8,7 +8,7 @@ using Test
 
 using NEOs: propres
 
-@testset "2018 LA" begin
+@testset "B-plane" begin
 
     # Fetch optical astrometry
     radec = fetch_radec_mpc("designation" => "2018 LA")


### PR DESCRIPTION
This PR adds `outlier_rejection_carpino03` which performs the outlier rejection algorithm from Carpino et al. (2003) during orbital fit iterations (currently proof-of-concept). This PR also changes the current implementation of Carpino et al. scheme, e.g. in this line:
https://github.com/PerezHz/NEOs.jl/blob/2e0c6846e3f71e4e6b2b9b056491f9f27638b8b8/src/orbitdetermination/least_squares.jl#L99
where I reckon the weights should be inverted? i.e.:
```
γ = [inv(w_α) zero(T); zero(T) inv(w_δ)] 
```
(or at least the notation description at start of page 251 in Carpino's paper was enough to confuse me 😅). With this approach, the K-means clustering-based outlier rejection and the Carpino et al. (2003) scheme give essentially the same results as currently done in tests for 2007 VV7.