### PR TITLE
Improve time scale conversion-related code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.8.11"
+version = "0.8.12"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/pha/apophis.jl
+++ b/pha/apophis.jl
@@ -41,7 +41,7 @@ function parse_commandline()
 
     @add_arg_table! s begin
         "--jd0"
-            help = "Initial date"
+            help = "Initial epoch calendar date (TDB)"
             arg_type = DateTime
             default = DateTime(2020, 12, 17)
         "--varorder"
@@ -104,7 +104,7 @@ function main(dynamics::D, maxsteps::Int, jd0_datetime::DateTime, nyears_bwd::T,
               abstol::T, parse_eqs::Bool) where {T <: Real, D}
 
     # Initial conditions from Apophis JPL solution #197
-    q00 = kmsec2auday(apophisposvel197(datetime2et(jd0_datetime)))
+    q00 = kmsec2auday(apophisposvel197(dtutc2et(jd0_datetime)))
 
     # Perturbation to nominal initial condition (Taylor1 jet transport)
     # vcat(fill(1e-8, 6), 1e-14, 1e-15) are the scaling factors for jet transport perturbation,

--- a/scripts/distributed.jl
+++ b/scripts/distributed.jl
@@ -20,7 +20,7 @@ end
     const apophisjlpath = pkgdir(Apophis)
     const radarobsfile = joinpath(apophisjlpath, "Apophis_JPL_data_2012_2013.dat")
     const dynamics = RNp1BP_pN_A_J23E_J2S_ng_eph_threads!
-    const t0 = datetime2julian(DateTime(2008,9,24,0,0,0)) #starting time of integration
+    const t0 = datetime2julian(DateTime(2008,9,24,0,0,0)) #starting time of integration (TDB)
     const tmax = t0+365.25nyears #final time of integration
     @show t0 == 2454733.5
     @show tmax

--- a/scripts/main.jl
+++ b/scripts/main.jl
@@ -20,7 +20,7 @@ const quadmath = false # use quadruple precision
 const debias_table = "2018" # "2014", "hires2018"
 const apophisjlpath = pkgdir(NEOs)
 const dynamics = RNp1BP_pN_A_J23E_J2S_ng_eph_threads!
-const jd0 = datetime2julian(DateTime(2008,9,24,0,0,0)) #Julian date of integration initial time
+const jd0 = datetime2julian(DateTime(2008,9,24,0,0,0)) #Julian date (TDB) of integration initial time
 @show jd0 == 2454733.5
 const t0 = 0.0 # integration initial time
 

--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -47,8 +47,8 @@ export hasdelay, hasdoppler, delay, doppler, rcvr, xmit, read_radar_jpl, write_r
 # NEOCPObject
 export fetch_objects_neocp, get_radec_neocp, fetch_radec_neocp, get_orbits_neocp
 # Units
-export julian2etsecs, etsecs2julian, datetime2et, et_to_200X, days_to_200X, datetime_to_200X,
-       datetime2days, days2datetime, rad2arcsec, arcsec2rad, mas2rad
+export julian2etsecs, etsecs2julian, dtutc2et, dtutc2jdtdb, et_to_200X, days_to_200X,
+       datetime_to_200X, datetime2days, days2datetime, rad2arcsec, arcsec2rad, mas2rad
 # JPL ephemerides
 export loadjpleph, sunposvel, earthposvel, moonposvel, apophisposvel197, apophisposvel199
 # PE and NEOs ephemerides

--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -87,5 +87,6 @@ include("propagation/propagation.jl")
 include("orbitdetermination/orbitdetermination.jl")
 include("postprocessing/outlier_rejection.jl")
 include("init.jl")
+include("deprecated.jl")
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+Base.@deprecate datetime2et(t) dtutc2et(t)

--- a/src/observations/process_radar.jl
+++ b/src/observations/process_radar.jl
@@ -273,7 +273,7 @@ function compute_delay(observatory::ObservatoryMPC{T}, t_r_utc::DateTime; tord::
                        xva::AstEph) where {T <: AbstractFloat, EarthEph, SunEph, AstEph}
 
     # Transform receiving time from UTC to TDB seconds since j2000
-    et_r_secs_0 = datetime2et(t_r_utc)
+    et_r_secs_0 = dtutc2et(t_r_utc)
     # Auxiliary to evaluate JT ephemeris
     xva1et0 = xva(et_r_secs_0)[1]
     # et_r_secs_0 as a Taylor polynomial
@@ -532,7 +532,7 @@ function radar_astrometry(astradardata::Vector{RadarJPL{T}}; xva::AstEph, kwargs
     # UTC time of first radar observation
     utc1 = astradardata[1].date
     # TDB seconds since J2000.0 for first astrometric observation
-    et1 = datetime2et(utc1)
+    et1 = dtutc2et(utc1)
     # Asteroid ephemeris at et1
     a1_et1 = xva(et1)[1]
     # Type of asteroid ephemeris

--- a/src/observations/process_radec.jl
+++ b/src/observations/process_radec.jl
@@ -127,7 +127,7 @@ function compute_radec(observatory::ObservatoryMPC{T}, t_r_utc::DateTime; niter:
                        xvs::SunEph = sunposvel, xve::EarthEph = earthposvel,
                        xva::AstEph) where {T <: AbstractFloat, SunEph, EarthEph, AstEph}
     # Transform receiving time from UTC to TDB seconds since J2000
-    et_r_secs = datetime2et(t_r_utc)
+    et_r_secs = dtutc2et(t_r_utc)
     # Sun barycentric position and velocity at receive time
     rv_s_t_r = xvs(et_r_secs)
     r_s_t_r = rv_s_t_r[1:3]
@@ -265,7 +265,7 @@ function compute_radec(obs::Vector{RadecMPC{T}}; xva::AstEph, kwargs...) where {
     # UTC time of first astrometric observation
     utc1 = obs[1].date
     # TDB seconds since J2000.0 for first astrometric observation
-    et1 = datetime2et(utc1)
+    et1 = dtutc2et(utc1)
     # Asteroid ephemeris at et1
     a1_et1 = xva(et1)[1]
     # Type of asteroid ephemeris
@@ -391,7 +391,7 @@ function debiasing(obs::RadecMPC{T}, mpc_catalogue_codes_201X::Vector{String}, t
         # pmDEC: proper motion correction in DEC [mas/yr]
         dRA, dDEC, pmRA, pmDEC = bias_matrix[pix_ind, 4*cat_ind-3:4*cat_ind]
         # Seconds since J2000 (TDB)
-        et_secs_i = datetime2et(obs.date)
+        et_secs_i = dtutc2et(obs.date)
         # Seconds sinde J2000 (TT)
         tt_secs_i = et_secs_i - ttmtdb(et_secs_i/daysec)
         # Years since J2000
@@ -555,7 +555,7 @@ function residuals(radec::Vector{RadecMPC{T}}, mpc_catalogue_codes_201X::Vector{
     # UTC time of first astrometric observation
     utc1 = date(radec[1])
     # TDB seconds since J2000.0 for first astrometric observation
-    et1 = datetime2et(utc1)
+    et1 = dtutc2et(utc1)
     # Asteroid ephemeris at et1
     a1_et1 = xva(et1)[1]
     # Type of asteroid ephemeris

--- a/src/observations/topocentric.jl
+++ b/src/observations/topocentric.jl
@@ -139,7 +139,7 @@ function obsposECEF(observatory::ObservatoryMPC{T}; eop::Union{EopIau1980, EopIa
 
     if issatellite(observatory) || isoccultation(observatory)
         # Ephemeris seconds since J2000
-        et = datetime2et(observatory.date)
+        et = dtutc2et(observatory.date)
         # Earth-Centered Inertial position position of observer
         posvel_ECI = obsposvelECI(observatory, et; eop)
         # UTC seconds
@@ -276,7 +276,7 @@ function obsposvelECI(observatory::ObservatoryMPC{T}, et::U;
     oneU = one(et)
 
     if issatellite(observatory) || isoccultation(observatory)
-        # @assert datetime2et(observatory.date) == cte(et)
+        # @assert dtutc2et(observatory.date) == cte(et)
         return [observatory.long * oneU, observatory.cos * oneU, observatory.sin * oneU,
                 zero(et), zero(et), zero(et)]
     else
@@ -311,8 +311,8 @@ function obsposvelECI(observatory::ObservatoryMPC{T}, et::U;
 end
 
 function obsposvelECI(x::RadecMPC{T}; eop::Union{EopIau1980, EopIau2000A} = eop_IAU2000A) where {T <: AbstractFloat}
-    return obsposvelECI(x.observatory, datetime2et(x.date); eop)
+    return obsposvelECI(x.observatory, dtutc2et(x.date); eop)
 end
 function obsposvelECI(x::RadarJPL{T}; eop::Union{EopIau1980, EopIau2000A} = eop_IAU2000A) where {T <: AbstractFloat}
-    return obsposvelECI(x.rcvr, datetime2et(x.date); eop)
+    return obsposvelECI(x.rcvr, dtutc2et(x.date); eop)
 end

--- a/src/orbitdetermination/admissibleregion.jl
+++ b/src/orbitdetermination/admissibleregion.jl
@@ -84,7 +84,7 @@ function AdmissibleRegion(tracklet::Tracklet{T}, params::NEOParameters{T}) where
     # Time of observation [days since J2000]
     t_days = datetime2days(t_datetime)
     # Time of observation [et seconds]
-    t_et = datetime2et(t_datetime)
+    t_et = dtutc2et(t_datetime)
     # Heliocentric position of the observer
     q = params.eph_ea(t_days) + kmsec2auday(obsposvelECI(obs, t_et)) - params.eph_su(t_days)
     # Admissible region coefficients
@@ -635,7 +635,7 @@ function attr2bary(A::AdmissibleRegion{T}, a::Vector{U},
     t = datetime2days(A.date) - ρ/c_au_per_day
     # TO DO: `et::TaylorN` is too slow for `adam` due to
     # SatelliteToolboxTransformations overloads in src/observations/topocentric.jl
-    et = datetime2et(A.date) - cte(cte(ρ))/c_au_per_sec
+    et = dtutc2et(A.date) - cte(cte(ρ))/c_au_per_sec
     # Line of sight vectors
     ρ_unit, ρ_α, ρ_δ = topounitpdv(α, δ)
     # Heliocentric position of the observer

--- a/src/orbitdetermination/gaussinitcond.jl
+++ b/src/orbitdetermination/gaussinitcond.jl
@@ -231,7 +231,7 @@ function gauss_method(observatories::Vector{ObservatoryMPC{T}}, dates::Vector{Da
     @assert issorted(dates) "Observations must be in temporal order"
 
     # Times of observation [et]
-    t_et = datetime2et.(dates)
+    t_et = dtutc2et.(dates)
     # Times of observation [days since J2000]
     t_days = t_et ./ daysec
 

--- a/src/orbitdetermination/neosolution.jl
+++ b/src/orbitdetermination/neosolution.jl
@@ -240,7 +240,7 @@ function uncertaintyparameter(radec::Vector{RadecMPC{T}}, sol::NEOSolution{T, T}
                               dynamics::D = newtonian!) where {T <: Real, D}
     # Reduce tracklets by polynomial regression
     tracklets = reduce_tracklets(radec)
-    # Epoch [julian days]
+    # Epoch [Julian days TDB]
     jd0 = sol.bwd.t0 + PE.J2000
     # Barycentric initial conditions
     q0 = sol(sol.bwd.t0)

--- a/src/orbitdetermination/orbitdetermination.jl
+++ b/src/orbitdetermination/orbitdetermination.jl
@@ -7,7 +7,7 @@ include("admissibleregion.jl")
 function _proprestimes(radec::Vector{RadecMPC{T}}, jd0::U, params::NEOParameters{T}) where {T <: Real, U <: Number}
     # Time of first (last) observation
     t0, tf = datetime2julian(date(radec[1])), datetime2julian(date(radec[end]))
-    # Epoch (plain)
+    # TDB epoch (plain)
     _jd0_ = cte(cte(jd0))
     # Years in backward (forward) integration
     nyears_bwd = -(_jd0_ - t0 + params.bwdoffset) / yr
@@ -81,7 +81,7 @@ Compute an orbit via Jet Transport Least Squares.
 
 - `radec::Vector{RadecMPC{T}}`: vector of optical astrometry.
 - `tracklets::Vector{Tracklet{T}},`: vector of tracklets.
-- `jd0::V`: reference epoch [julian days].
+- `jd0::V`: reference epoch [Julian days TDB].
 - `q::Vector{TaylorN{T}}`: jet transport initial condition.
 - `i::Int`: index of `tracklets` to start least squares fit.
 - `params::NEOParameters{T}`: see `Jet Transport Least Squares Parameters` of [`NEOParameters`](@ref).
@@ -253,7 +253,7 @@ function orbitdetermination(radec::Vector{RadecMPC{T}}, sol::NEOSolution{T, T}, 
                             dynamics::D = newtonian!) where {T <: Real, D}
     # Reduce tracklets by polynomial regression
     tracklets = reduce_tracklets(radec)
-    # Reference epoch [julian days]
+    # Reference epoch [Julian days TDB]
     jd0 = sol.bwd.t0 + PE.J2000
     # Plain barycentric initial condition
     q0 = sol(sol.bwd.t0)

--- a/src/postprocessing/outlier_rejection.jl
+++ b/src/postprocessing/outlier_rejection.jl
@@ -25,7 +25,7 @@ Refine an orbit, computed by [`orbitdetermination`](@ref), via propagation and/o
 """
 function outlier_rejection(radec::Vector{RadecMPC{T}}, sol::NEOSolution{T, T},
                            params::NEOParameters{T}; dynamics::D = newtonian!) where {T <: Real, D}
-    # Julian day to start propagation
+    # Julian day (TDB) to start propagation
     jd0 = sol.bwd.t0 + PE.J2000
     # Initial conditions (T)
     q0 = sol(sol.bwd.t0)

--- a/src/propagation/asteroid_dynamical_models.jl
+++ b/src/propagation/asteroid_dynamical_models.jl
@@ -90,7 +90,7 @@ See also [`PlanetaryEphemeris.NBP_pN_A_J23E_J23M_J2S!`](@ref).
 """ RNp1BP_pN_A_J23E_J2S_ng_eph_threads!
 
 function RNp1BP_pN_A_J23E_J2S_ng_eph_threads!(dq, q, params, t)
-    # Julian date of start time
+    # Julian date (TDB) of start time
     local jd0 = params.jd0
     # Days since J2000.0 = 2.451545e6
     local dsj2k = t + (jd0 - JD_J2000)
@@ -664,7 +664,7 @@ function RNp1BP_pN_A_J23E_J2S_ng_eph_threads!(dq, q, params, t)
 end
 
 function RNp1BP_pN_A_J23E_J2S_eph_threads!(dq, q, params, t)
-    # Julian date of start time
+    # Julian date (TDB) of start time
     local jd0 = params.jd0
     # Days since J2000.0 = 2.451545e6
     local dsj2k = t + (jd0 - JD_J2000)
@@ -1200,7 +1200,7 @@ function RNp1BP_pN_A_J23E_J2S_eph_threads!(dq, q, params, t)
 end
 
 function newtonian!(dq, q, params, t)
-    # Julian date of start time
+    # Julian date (TDB) of start time
     local jd0 = params.jd0
     # Days since J2000.0 = 2.451545e6
     local dsj2k = t + (jd0 - JD_J2000)

--- a/src/propagation/propagation.jl
+++ b/src/propagation/propagation.jl
@@ -30,7 +30,7 @@ Return a `PropagationBuffer` object with pre-allocated memory for `propagate`.
 # Arguments
 
 - `dynamics::D`: dynamical model function.
-- `jd0::V`: initial Julian date.
+- `jd0::V`: initial Julian date (TDB).
 - `tlim::Tuple{T, T}`: ephemeris timespan [in days since J2000].
 - `q0::Vector{U}`: vector of initial conditions.
 - `params::NEOParameters{T}`: see [`NEOParameters`](@ref).
@@ -96,7 +96,7 @@ Return `true` and the asteroid's radial velocity with respect to the Earth.
 """
 function rvelea(dx, x, params, t)
 
-    jd0 = params.jd0                                  # Julian date of start time
+    jd0 = params.jd0                                  # Julian date (TDB) of start time
     dsj2k = t + (jd0 - JD_J2000)                      # Days since J2000
     ss16asteph_t = evaleph(params.sseph, dsj2k, x[1]) # Evaluate ephemeris at dsj2k
     N = params.N                                      # Total number of bodies
@@ -148,12 +148,13 @@ end
     propagate(dynamics::D, jd0::V, tspan::T, q0::Vector{U},
               params::NEOParameters{T}) where {T <: Real, U <: Number, V <: Number, D}
 
-Integrate the orbit of a NEO via the Taylor method.
+Integrate the a NEO orbit via the Taylor method. The initial Julian date `jd0` is assumed to
+be in TDB time scale.
 
 # Arguments
 
 - `dynamics::D`: dynamical model function.
-- `jd0::V`: initial Julian date.
+- `jd0::V`: initial Julian date (TDB).
 - `tspan::T`: time span of the integration [in years].
 - `q0::Vector{U}`: vector of initial conditions.
 - `params::NEOParameters{T}`: see [`NEOParameters`](@ref).
@@ -203,7 +204,7 @@ Integrate the orbit of a NEO via the Taylor method while finding the zeros of
 # Arguments
 
 - `dynamics::D`: dynamical model function.
-- `jd0::V`: initial Julian date.
+- `jd0::V`: initial Julian date (TDB).
 - `tspan::T`: time span of the integration [in years].
 - `q0::Vector{U}`: vector of initial conditions.
 - `params::NEOParameters{T}`: see [`NEOParameters`](@ref).
@@ -258,7 +259,7 @@ Compute the Lyapunov spectrum of a NEO.
 # Arguments
 
 - `dynamics::D`: dynamical model function.
-- `jd0::V`: initial Julian date.
+- `jd0::V`: initial Julian date (TDB).
 - `tspan::T`: time span of the integration [in Julian days].
 - `q0::Vector{U}`: vector of initial conditions.
 - `params::NEOParameters{T}`: see [`NEOParameters`](@ref).

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -28,7 +28,7 @@ using InteractiveUtils: methodswith
 
         # Dynamical function
         dynamics = RNp1BP_pN_A_J23E_J2S_eph_threads!
-        # Initial time [Julian date]
+        # Initial time [Julian date TDB]
         jd0 = datetime2julian(DateTime(2023, 2, 25, 0, 0, 0))
         # Time of integration [years]
         nyears = 0.2
@@ -151,7 +151,7 @@ using InteractiveUtils: methodswith
 
         # Dynamical function
         dynamics = RNp1BP_pN_A_J23E_J2S_ng_eph_threads!
-        # Initial time [Julian date]
+        # Initial time [Julian date TDB]
         jd0 = datetime2julian(DateTime(2004, 6, 1))
         # Time of integration [years]
         nyears = 9.0
@@ -261,7 +261,7 @@ using InteractiveUtils: methodswith
 
         # Dynamical function
         dynamics = RNp1BP_pN_A_J23E_J2S_eph_threads!
-        # Initial date of integration [julian days]
+        # Initial date of integration [Julian date TDB]
         jd0 = datetime2julian(DateTime(2029, 4, 13, 20))
         # Time of integration [years]
         nyears = 0.02
@@ -320,7 +320,7 @@ using InteractiveUtils: methodswith
         # integration parameters
         nyears::Float64 = 10.0
         varorder::Int = 1
-        jd0::Float64 = datetime2julian(DateTime(2004,6,1)) #Julian date of integration initial time
+        jd0::Float64 = datetime2julian(DateTime(2004,6,1)) #Julian date (TDB) of integration initial time
         # 7-DOF nominal solution from pha/apophis.jl script at epoch 2004-06-01T00:00:00.000 (TDB)
         q00::Vector{Float64} = [-1.0506627988664696, -0.060643124245514164, -0.0499709975200415, 0.0029591416313078838, -0.014232335581939919, -0.0052184125285361415, -2.898870403031058e-14, 0.0]
         scalings::Vector{Float64} = vcat(fill(1e-8, 6), 1e-14)


### PR DESCRIPTION
This PR improves docstrings and modifies internal code to make more explicit the internal conventions used to call `propagate` and time scale conversion related methods. Namely, the current convention is that `jd0`, the second argument in the call to `propagate`, is a Julian date in TDB time scale. This PR also deprecates `datetime2et` and renames it as `dtutc2et`, to make more explicit the fact that such method is meant to be used to transform a UTC time and date instantiated as a `DateTime`, and convert it to ET seconds, i.e., TDB seconds since J2000.0. This PR also adds a new method, `dtutc2jdtdb`, which transforms a UTC date and time (instantiated as a `DateTime`) to a TDB Julian date (i.e., JDTDB).

Potentially, some code in `AdmisibleRegion` and related methods might need to be updated, where `Dates.datetime2julian` is sometimes used to transform from a UTC date and time format to a Julian date in TDB, but where the new `NEOs.dtutc2jdtdb` method should be used instead.

Since the changes contained here are non-breaking, I propose to merge this (modulo any suggestions and improvements that can be always be added) and then tackle potential consistency issues related to internal use of `Dates.datetime2julian` in another PR.

cc: @lbenet @LuEdRaMo 