### PR TITLE
Fix numerical stability in `arG`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         arch:
           - x64

--- a/src/orbitdetermination/admissibleregion.jl
+++ b/src/orbitdetermination/admissibleregion.jl
@@ -195,15 +195,29 @@ arS(A::AdmissibleRegion{T}, ρ::S) where {T <: Real, S <: Number} = arS(A.coeffs
 @doc raw"""
     arG(A::AdmissibleRegion{T}, ρ::S) where {T <: Real, S <: Number}
 
+Auxiliary function to compute the root of G ([`AdmissibleRegion`](@ref)) from
+an [`AdmissibleRegion`](@ref).
+"""
+G⁻¹0(coeffs::Vector) = cbrt(2 * k_gauss^2 * μ_ES / coeffs[3])
+G⁻¹0(A::AdmissibleRegion) = G⁻¹0(A.coeffs)
+
+@doc raw"""
+    arG(A::AdmissibleRegion{T}, ρ::S) where {T <: Real, S <: Number}
+
 G function of an [`AdmissibleRegion`](@ref).
 
 !!! reference
     See equation (8.13) of https://doi.org/10.1017/CBO9781139175371.
 """
 function arG(coeffs::Vector{T}, ρ::S) where {T <: Real, S <: Number}
-    return 2 * k_gauss^2 * μ_ES / ρ - coeffs[3] * ρ^2
+    if ρ == G⁻¹0(coeffs)
+        return coeffs[3] * zero(ρ)
+    else
+        return 2 * k_gauss^2 * μ_ES / ρ - coeffs[3] * ρ^2
+    end
 end
 arG(A::AdmissibleRegion{T}, ρ::S) where {T <: Real, S <: Number} = arG(A.coeffs, ρ)
+
 
 @doc raw"""
     arenergycoeffs(A::AdmissibleRegion{T}, ρ::S, [boundary::Symbol]) where {T <: Real, S <: Number}
@@ -300,7 +314,7 @@ function _helrangerates(coeffs::Vector{T}, a_max::T, ρ::S) where {T, S <: Real}
 end
 
 function _georangerates(coeffs::Vector{T}, ρ::S) where {T, S <: Real}
-    ρ0 = min(R_SI, cbrt(2 * k_gauss^2 * μ_ES / coeffs[3]))
+    ρ0 = min(R_SI, G⁻¹0(coeffs))
     !(0 < ρ <= ρ0) && return Vector{T}(undef, 0)
     a, b, c = _argeoenergycoeffs(coeffs, ρ)
     d = b^2 - 4*a*c
@@ -347,7 +361,7 @@ function _helrangerate(coeffs::Vector{T}, a_max::T, ρ::T, m::Symbol) where {T <
 end
 
 function _georangerate(coeffs::Vector{T}, ρ::T, m::Symbol) where {T <: Real}
-    ρ0 = min(R_SI, cbrt(2 * k_gauss^2 * μ_ES / coeffs[3]))
+    ρ0 = min(R_SI, G⁻¹0(coeffs))
     @assert 0 < ρ <= ρ0 "No solutions for geocentric energy outside 0 < ρ <= ρ0"
     a, b, c = _argeoenergycoeffs(coeffs, ρ)
     d = b^2 - 4*a*c
@@ -455,7 +469,7 @@ an admissible region with coefficients `coeffs`.
 """
 function _geomaxrange(coeffs::Vector{T}) where {T <: Real}
     # Initial guess
-    ρ_max = min(R_SI, cbrt(2 * k_gauss^2 * μ_ES / coeffs[3]))
+    ρ_max = min(R_SI, G⁻¹0(coeffs))
     # Make sure G(ρ) ≥ 0 and there is at least one _georangerate solution
     niter = 0
     while _argeoenergydis(coeffs, ρ_max) < 0 || length(_georangerates(coeffs, ρ_max)) == 0

--- a/src/orbitdetermination/admissibleregion.jl
+++ b/src/orbitdetermination/admissibleregion.jl
@@ -211,7 +211,7 @@ G function of an [`AdmissibleRegion`](@ref).
 """
 function arG(coeffs::Vector{T}, ρ::S) where {T <: Real, S <: Number}
     if ρ == G⁻¹0(coeffs)
-        return coeffs[3] * zero(ρ)
+        return zero(coeffs[3] * ρ)
     else
         return 2 * k_gauss^2 * μ_ES / ρ - coeffs[3] * ρ^2
     end

--- a/test/orbitdetermination.jl
+++ b/test/orbitdetermination.jl
@@ -261,7 +261,8 @@ end
         a, b = rangerates(A, A.ρ_domain[1], :inner)
         @test a ≈ -b atol = 1e-18
         @test minimum(rangerates(A, A.ρ_domain[2], :outer)) == A.Fs[3, 2]
-        @test isempty(rangerates(A, ρ0, :inner))
+        @test !isempty(rangerates(A, ρ0, :inner))
+        @test rangerates(A, ρ0, :inner) == [zero(ρ0)]
         @test isempty(rangerates(A, A.ρ_domain[2] + 1.0, :outer))
         @test isempty(rangerates(A, ρ0 + 1.0, :inner))
         @test rangerate(A, A.ρ_domain[1], :min, :outer) == A.v_ρ_domain[1]


### PR DESCRIPTION
This is just a proposal for a small fix on top of #91 to aid numerical stability of `arG`, which caused unit tests to fail locally on my machine (macOS), and also reproduced it in the CI by re-enabling macOS tests. An even better fix could be to add a numerical threshold in `arG` to check is we are close to the root of G which marks the boundary of the AR in the range, but we can look at that after merging #91. I have also (temporarily) re-enabled testing macOS. cc: @lbenet @LuEdRaMo  