### PR TITLE
Extend JLD2 to support v0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.17.1"
+version = "0.17.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
Following https://github.com/JuliaDiff/TaylorSeries.jl/pull/391, this PR updates the `JLD2` compat entry to include the latest minor version 0.6.