### PR TITLE
Update OD tests bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.24.6"
+version = "0.24.7"
 
 [deps]
 AngleBetweenVectors = "ec570357-d46e-52ed-9726-18773498274d"

--- a/test/orbitdetermination.jl
+++ b/test/orbitdetermination.jl
@@ -212,7 +212,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -257,7 +257,7 @@ end
             4.045356567755751E+01, 3.261403954217091E+02, 1.216665112960870E+02]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (7.6E-01, 8.3E-01, 5.5E-12, 6.2E-15, 8.2E-14),
+        jpl_compatibility_tests(orbit, params, (7.6E-01, 8.3E-01, 5.5E-12, 4.6E-14, 8.2E-14),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -317,7 +317,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        jpl_compatibility_tests(orbit1, params, (3.1E-01, 4.5E-01, 4.0E-11, 6.0E-12, 6.0E-12),
+        jpl_compatibility_tests(orbit1, params, (3.1E-01, 4.5E-01, 4.0E-11, 8.2E-12, 6.0E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit1, params)
@@ -353,7 +353,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -398,7 +398,7 @@ end
             1.725712172730245E+02, 2.413793589329106E+02, 3.538743602962668E+02]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (5.6E-03, 5.5E-03, 1.7E-11, 5.4E-15, 2.7E-12),
+        jpl_compatibility_tests(orbit, params, (5.6E-03, 5.5E-03, 1.7E-11, 7.0E-15, 2.7E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -436,7 +436,7 @@ end
         # Initial Orbit Determination
         orbit = gaussiod(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -481,7 +481,7 @@ end
             1.322293305412568E+01, 2.778787985886902E+02, 3.530120962605258E+02]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (1.6E-01, 2.4E-01, 2.0E-11, 6.5E-14, 1.5E-12),
+        jpl_compatibility_tests(orbit, params, (1.6E-01, 2.4E-01, 2.0E-11, 4.3E-13, 1.5E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -514,7 +514,7 @@ end
         # Admissible region
         A = AdmissibleRegion(tracklet, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Zero AdmissibleRegion
         @test iszero(zero(AdmissibleRegion{Float64}))
@@ -662,7 +662,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -713,7 +713,7 @@ end
             1.294946774085543E+02, 3.442349856198504E+02, 2.206164242012555E+01]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (1.3E-02, 1.7E-02, 6.6E-12, 3.8E-13, 3.8E-13),
+        jpl_compatibility_tests(orbit, params, (1.3E-02, 1.7E-02, 1.3E-11, 3.8E-13, 3.8E-13),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -748,7 +748,7 @@ end
         # Initial Orbit Determination (with outlier rejection)
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -894,7 +894,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -945,7 +945,7 @@ end
             5.237781301766019E+01, 1.016022028285875E+02, 3.243429036265208E+02]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (3.0E-01, 3.8E-01, 1.5E-10, 4.7E-13, 3.2E-12),
+        jpl_compatibility_tests(orbit, params, (3.0E-01, 3.8E-01, 1.5E-10, 7.9E-13, 3.2E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -980,7 +980,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -1025,7 +1025,7 @@ end
             2.339645303327229E+02, 1.941265709953888E+02, 3.288450951861228E+02]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (2.0E-01, 3.0E-01, 5.1E-09, 1.5E-11, 1.4E-11),
+        jpl_compatibility_tests(orbit, params, (2.0E-01, 3.0E-01, 5.1E-09, 1.5E-11, 1.5E-11),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -1085,7 +1085,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        jpl_compatibility_tests(orbit1, params, (1.7E-01, 1.8E-01, 6.3E-08, 1.8E-10, 1.4E-09),
+        jpl_compatibility_tests(orbit1, params, (1.7E-01, 1.8E-01, 2.2E-07, 1.8E-10, 1.4E-09),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit1, params)
@@ -1151,7 +1151,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params; initcond = iodinitcond)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,
@@ -1197,7 +1197,7 @@ end
             2.293324466168822E+02, 3.254353160068554E+02, 2.033836565098925E+01]
         JPL_EQN = keplerian2equinoctial(JPL_KEP, epoch(orbit) + MJD2000; μ = μ_S)
         JPL_ATTR = cartesian2attributable(JPL_CAR - params.eph_ea(epoch(orbit)))
-        jpl_compatibility_tests(orbit, params, (5.3E-01, 1.4E+00, 8.2E-13, 8.9E-15, 5.2E-14),
+        jpl_compatibility_tests(orbit, params, (5.3E-01, 1.4E+00, 1.4E-12, 8.9E-15, 5.2E-14),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
         H, dH = absolutemagnitude(orbit, params)
@@ -1256,7 +1256,7 @@ end
         # Refine orbit (both optical and radar astrometry)
         orbit1 = orbitdetermination(od1, orbit0, params)
 
-        # Values by Jan 30, 2026
+        # Values by Apr 4, 2026
 
         # Check type
         @test isa(orbit1, LeastSquaresOrbit{typeof(newtonian!), Float64, Float64,


### PR DESCRIPTION
Currently, tests fail on newer Macs (as reported by @lbenet and @PerezHz) due to the bounds in the OD JPL compatibility tests being too restrictive. This PR updates such bounds to be compatible with a Mac mini M2.  