### PR TITLE
New function `print_mpec_residuals`

### DIFF
--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -95,7 +95,7 @@ export bwdfwdeph, propres, propres!
 export leastsquares, leastsquares!, tryls, outlier_rejection!, project, critical_value
 export variables, epoch, firsttime, lasttime, noptical, nradar, minmaxdates, optical,
        sigmas, snr, keplerian, equinoctial, attributable, uncertaintyparameter,
-       absolutemagnitude, diameter, mass, shiftepoch
+       absolutemagnitude, diameter, mass, shiftepoch, print_mpec_residuals
 export topo2bary, bary2topo, attr2bary, tsaiod
 export mmov, gaussmethod, gaussiod, jtls, issinglearc, initialorbitdetermination,
        orbitdetermination, linkage

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -73,15 +73,23 @@ function mpec_residual(x::AbstractOpticalAstrometry, y::OpticalResidual)
     sd = Dates.format(date(x), "yymmdd")
     so = observatorycode(x)
     α, δ = ra(y), dec(y)
-    sα = @sprintf("%5.1f", abs(α)) * if abs(α) < 0.05
-        "  "
+    sα = if abs(α) < 100
+        @sprintf("%5.1f", abs(α)) * if abs(α) < 0.05
+            "  "
+        else
+            α ≥ 0 ? "+ " : "- "
+        end
     else
-        α ≥ 0 ? "+ " : "- "
+        @sprintf("%5.2f", abs(α / 3_600)) * (α ≥ 0 ? "+ " : "- ")
     end
-    sδ = @sprintf("%5.1f", abs(δ)) * if abs(δ) < 0.05
-        "  "
+    sδ = if abs(δ) < 100
+        @sprintf("%5.1f", abs(δ)) * if abs(δ) < 0.05
+            "  "
+        else
+            δ ≥ 0 ? "+ " : "- "
+        end
     else
-        δ ≥ 0 ? "+ " : "- "
+        @sprintf("%5.2f", abs(δ / 3_600)) * (δ ≥ 0 ? "+ " : "- ")
     end
     s = string(sd, " ", so, sα, sδ)
     if isoutlier(y)

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -108,7 +108,7 @@ function print_mpec_residuals(io::IO, x::AbstractOpticalVector,
     print(
         io,
         "Residuals in seconds of arc\n",
-        join(join.(eachrow(m), "   "), '\n')
+        join(join.(eachrow(m), "   "), '\n'), '\n'
     )
     return nothing
 end

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -68,6 +68,51 @@ function show(io::IO, x::OpticalResidual)
         @sprintf("%+.5f", cte(dec(x))), outlier_flag)
 end
 
+# Methods to print optical residuals in the MPEC format
+function mpec_residual(x::AbstractOpticalAstrometry, y::OpticalResidual)
+    sd = Dates.format(date(x), "yymmdd")
+    so = observatorycode(x)
+    α, δ = ra(y), dec(y)
+    sα = @sprintf("%5.1f", abs(α)) * if abs(α) < 0.05
+        "  "
+    else
+        α ≥ 0 ? "+ " : "- "
+    end
+    sδ = @sprintf("%5.1f", abs(δ)) * if abs(δ) < 0.05
+        "  "
+    else
+        δ ≥ 0 ? "+ " : "- "
+    end
+    s = string(sd, " ", so, sα, sδ)
+    if isoutlier(y)
+        c = collect(s)
+        c[11], c[end] = '(', ')'
+        s = join(c)
+    end
+    return s
+end
+
+print_mpec_residuals(x::AbstractOpticalVector, y::AbstractResidualVector) =
+    print_mpec_residuals(stdout, x, y)
+
+function print_mpec_residuals(io::IO, x::AbstractOpticalVector,
+                              y::AbstractResidualVector)
+    @assert length(x) == length(y) "Observations and residuals vectors must have \
+        the same length"
+    L = length(x)
+    Nrows = ceil(Int, L / 3)
+    v = Vector{String}(undef, 3Nrows)
+    @. v[1:L] = mpec_residual(x, y)
+    @. v[L+1:end] = ""
+    m = reshape(v, Nrows, 3)
+    print(
+        io,
+        "Residuals in seconds of arc\n",
+        join(join.(eachrow(m), "   "), '\n')
+    )
+    return nothing
+end
+
 # Evaluate methods
 evaluate(y::OpticalResidual{T, TaylorN{T}}, x::Vector{T}) where {T <: Real} =
     OpticalResidual{T, T}(y.ra(x), y.dec(x), y.wra, y.wdec, y.dra, y.ddec, y.corr, y.outlier)

--- a/src/orbitdetermination/abstractorbit/abstractorbit.jl
+++ b/src/orbitdetermination/abstractorbit/abstractorbit.jl
@@ -579,6 +579,9 @@ section of [`Parameters`](@ref).
 mass(orbit::AbstractOrbit, params::Parameters) =
     mass(params.density, diameter(orbit, params))
 
+print_mpec_residuals(x::AbstractOrbit) = print_mpec_residuals(x.optical, x.ores)
+print_mpec_residuals(io::IO, x::AbstractOrbit) = print_mpec_residuals(io, x.optical, x.ores)
+
 function summary(orbit::AbstractOrbit)
     O = nameof(typeof(orbit))
     T, U = numtypes(orbit)

--- a/src/orbitdetermination/abstractorbit/abstractorbit.jl
+++ b/src/orbitdetermination/abstractorbit/abstractorbit.jl
@@ -579,6 +579,11 @@ section of [`Parameters`](@ref).
 mass(orbit::AbstractOrbit, params::Parameters) =
     mass(params.density, diameter(orbit, params))
 
+"""
+    print_mpec_residuals([io::IO], ::AbstractOrbit)
+
+Print to `io` the optical residuals of an orbit in the MPEC format.
+"""
 print_mpec_residuals(x::AbstractOrbit) = print_mpec_residuals(x.optical, x.ores)
 print_mpec_residuals(io::IO, x::AbstractOrbit) = print_mpec_residuals(io, x.optical, x.ores)
 

--- a/test/orbitdetermination.jl
+++ b/test/orbitdetermination.jl
@@ -228,7 +228,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -250,6 +250,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 9
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -317,6 +318,7 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 43
         @test nout(orbit1.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -371,7 +373,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -393,6 +395,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 6
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -455,7 +458,7 @@ end
         # Initial Orbit Determination
         orbit = gaussiod(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -477,6 +480,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 12
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -534,7 +538,7 @@ end
         # Admissible region
         A = AdmissibleRegion(tracklet, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Zero AdmissibleRegion
         @test iszero(zero(AdmissibleRegion{Float64}))
@@ -682,7 +686,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -710,6 +714,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 10
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -769,7 +774,7 @@ end
         # Initial Orbit Determination (with outlier rejection)
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -791,6 +796,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 16
         @test nout(orbit.ores) == 2
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -856,6 +862,7 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 19
         @test nout(orbit1.ores) == 2
+        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -917,7 +924,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -945,6 +952,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 7
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1004,7 +1012,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1026,6 +1034,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 18
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1093,6 +1102,7 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 97
         @test nout(orbit1.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -1177,7 +1187,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params; initcond = iodinitcond)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1200,6 +1210,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 6
         @test nout(orbit.ores) == 0
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1282,7 +1293,7 @@ end
         # Refine orbit (both optical and radar astrometry)
         orbit1 = orbitdetermination(od1, orbit0, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit1, RadarOrbit{Float64})
@@ -1312,6 +1323,7 @@ end
         @test notout(orbit1.rres) == 5
         @test nout(orbit1.ores) == 0
         @test nout(orbit1.rres) == 0
+        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -1380,7 +1392,7 @@ end
         # Linkage
         orbit = linkage(od, orbit, params)
 
-        # Values by May 24, 2026
+        # Values by June 30, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1402,6 +1414,7 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 43
         @test nout(orbit.ores) == 1
+        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success


### PR DESCRIPTION
This PR adds a new function `print_mpec_residuals` which prints the optical residuals of an `::AbstractOrbit` in the MPEC format.