### PR TITLE
New function `print_mpec_elements`

### DIFF
--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -93,9 +93,10 @@ export gm, frame, elements, iscircular, iselliptic, isparabolic, ishyperbolic, c
 export curvature
 export bwdfwdeph, propres, propres!
 export leastsquares, leastsquares!, tryls, outlier_rejection!, project, critical_value
-export variables, epoch, firsttime, lasttime, noptical, nradar, minmaxdates, optical,
-       sigmas, snr, keplerian, equinoctial, attributable, uncertaintyparameter,
-       absolutemagnitude, diameter, mass, shiftepoch, print_mpec_residuals
+export variables, designation, epoch, firsttime, lasttime, noptical, nradar, minmaxdates,
+       optical, sigmas, snr, keplerian, equinoctial, attributable, uncertaintyparameter,
+       absolutemagnitude, diameter, mass, shiftepoch, print_mpec_residuals,
+       print_mpec_elements
 export topo2bary, bary2topo, attr2bary, tsaiod
 export mmov, gaussmethod, gaussiod, jtls, issinglearc, initialorbitdetermination,
        orbitdetermination, linkage

--- a/src/astrometry/opticalades.jl
+++ b/src/astrometry/opticalades.jl
@@ -128,6 +128,18 @@ isdiscovery(x::OpticalADES) = !isempty(x.disc)
 
 isdeprecated(x::OpticalADES) = !isempty(x.deprecated)
 
+function designation(x::OpticalADES)
+    # If there is no number, use temporary designation
+    if !isempty(x.permid)
+        des = x.permid
+    elseif !isempty(x.provid)
+        des = x.provid
+    else
+        des = x.trksub
+    end
+    return des
+end
+
 # Print method for OpticalADES
 function show(io::IO, o::OpticalADES)
     # If there is no number, use temporary designation

--- a/src/astrometry/opticalmpc80.jl
+++ b/src/astrometry/opticalmpc80.jl
@@ -99,6 +99,15 @@ isdiscovery(x::OpticalMPC80) = x.discovery == '*'
 
 isdeprecated(x::OpticalMPC80) = x.note2 == 'X'
 
+function designation(x::OpticalMPC80)
+    if isempty(x.number)
+        des = 'I' ≤ x.desig[1] ≤ 'K' ? unpackdesig(x.desig) : x.desig
+    else
+        des = unpacknum(x.number)
+    end
+    return des
+end
+
 # Print method for OpticalMPC80
 function show(io::IO, o::OpticalMPC80)
     # If there is no number, use temporary designation

--- a/src/astrometry/opticalrwo.jl
+++ b/src/astrometry/opticalrwo.jl
@@ -177,6 +177,8 @@ trackletid(x::OpticalRWO) = ""
 
 isdeprecated(x::OpticalRWO) = x.T == 'X'
 
+designation(x::OpticalRWO) = x.design
+
 # Print method for OpticalRWO
 show(io::IO, o::OpticalRWO) = print(io, o.design, " α: ", @sprintf("%.5f",
     rad2deg(o.ra)), "° δ: ", @sprintf("%.5f", rad2deg(o.dec)), "° t: ", o.date,

--- a/src/orbitdetermination/abstractorbit/abstractorbit.jl
+++ b/src/orbitdetermination/abstractorbit/abstractorbit.jl
@@ -26,6 +26,9 @@ dof(x::AbstractOrbit) = dof(Val(dynamicalmodel(x)))
 variables(x::AbstractOrbit) = x.variables
 numvars(x::AbstractOrbit) = length(x.variables)
 
+# Object designation
+designation(x::AbstractOrbit) = designation(last(x.optical))
+
 """
     epoch(::AbstractOrbit)
 
@@ -580,12 +583,65 @@ mass(orbit::AbstractOrbit, params::Parameters) =
     mass(params.density, diameter(orbit, params))
 
 """
-    print_mpec_residuals([io::IO], ::AbstractOrbit)
+    print_mpec_residuals([io::IO], orbit)
 
-Print to `io` the optical residuals of an orbit in the MPEC format.
+Print to `io` the optical residuals of an `orbit` in the MPEC format.
 """
 print_mpec_residuals(x::AbstractOrbit) = print_mpec_residuals(x.optical, x.ores)
 print_mpec_residuals(io::IO, x::AbstractOrbit) = print_mpec_residuals(io, x.optical, x.ores)
+
+"""
+    print_mpec_elements([io::IO], orbit, params [, t])
+
+Print to `io` the keplerian elements of an `orbit` at time `t`
+[TDB days since J2000] in the MPEC format.
+"""
+print_mpec_elements(orbit::AbstractOrbit, params::Parameters, t::Real = epoch(orbit)) =
+    print_mpec_elements(stdout, orbit, params, t)
+
+# TO DO:
+# - Use MOID.jl to compute the minimum orbit intersection distance,
+# - Verify that the formulas for P_vec and Q_vec are correct.
+function print_mpec_elements(io::IO, orbit::AbstractOrbit, params::Parameters,
+                             t::Real = epoch(orbit))
+    jdt = t + PE.J2000 + ttmtdb(t) / daysec
+    dt = julian2datetime(jdt)
+    fd = day(dt) + Dates.value(dt - DateTime(Date(dt))) / (daysec * 1000)
+    G = params.slope
+    H = absolutemagnitude(orbit, params)[1]
+    U = uncertaintyparameter(orbit, params)
+    kep = keplerian(orbit, params, t)
+    n = meanmotion(kep)
+    M = meananomaly(kep)
+    e = eccentricity(kep)
+    a = semimajoraxis(kep)
+    i = inclination(kep)
+    ω = argperi(kep)
+    Ω = longascnode(kep)
+    P = (2π / yr) * sqrt(a^3 / μ_S)
+    P_vec = [
+        cosd(ω)*cosd(Ω) - sind(ω)*sind(Ω)*cosd(i),
+        cosd(ω)*sind(Ω) + sind(ω)*cosd(Ω)*cosd(i),
+        sind(ω)*sind(i)
+    ]
+    Q_vec = [
+        sind(ω)*cosd(Ω) + cosd(ω)*sind(Ω)*cosd(i),
+        cosd(ω)*cosd(Ω)*cosd(i) - sind(ω)*sind(Ω),
+        cosd(ω)*sind(i)
+    ]
+    print(
+        io,
+        "Orbital elements:\n",
+        @sprintf("%-56sEarth MOID = %.4f AU\n", designation(orbit), NaN),
+        @sprintf("Epoch %s %.8f TT = JDT %.8f%3sNEOs.jl\n", Dates.format(dt, "yyyy U"), fd, jdt, ""),
+        @sprintf("M%10.5f%14s(2000.0)%12sP%15sQ\n", M, "", "", ""),
+        @sprintf("n%13.8f%5sPeri.%11.5f%5s%+11.8f%5s%+11.8f\n", n, "", ω, "", P_vec[1], "", Q_vec[1]),
+        @sprintf("a%12.7f%6sNode %11.5f%5s%+11.8f%5s%+11.8f\n", a, "", Ω, "", P_vec[2], "", Q_vec[2]),
+        @sprintf("e%12.7f%6sIncl.%11.5f%5s%+11.8f%5s%+11.8f\n", e, "", i, "", P_vec[3], "", Q_vec[3]),
+        @sprintf("P%7.2f%11sH%8.2f%10sG%7.2f%11sU%4d\n", P, "", H, "", G, "", U),
+    )
+    return nothing
+end
 
 function summary(orbit::AbstractOrbit)
     O = nameof(typeof(orbit))

--- a/test/optical.jl
+++ b/test/optical.jl
@@ -38,6 +38,7 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         @test apophis.observatory == observatory(apophis) == search_observatory_code("691")
         @test apophis.source == apophis_s
 
+        @test designation(apophis) == "99942"
         @test measure(apophis) == (1.0739650841580173, 0.2952738332250385)
         @test rms(apophis) == (1.0, 1.0)
         @test debias(apophis) == (0.0, 0.0)
@@ -226,6 +227,7 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         idxs = findfirst("END_OF_HEADER", apophis_s)
         @test apophis.header == apophis_s[1:first(idxs)-1]
 
+        @test designation(apophis) == "99942"
         @test measure(apophis) == (1.0739650841580173, 0.2952738332250385)
         @test rms(apophis) == (0.612, 0.612)
         @test debias(apophis) == (-0.247, 0.14)
@@ -387,6 +389,7 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         @test apophis.deprecated == ""
         @test replace(apophis.source, " " => "") == replace(apophis_s[64:end-9], " " => "")
 
+        @test designation(apophis) == "99942"
         @test measure(apophis) == (1.073965142335659, 0.2952737556548495)
         @test rms(apophis) == (1.0, 1.0)
         @test debias(apophis) == (0.0, 0.0)

--- a/test/orbitdetermination.jl
+++ b/test/orbitdetermination.jl
@@ -228,11 +228,12 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2023 DW"
         @test length(suboptical) == nobs(od) == nobs(orbit) == 9
         @test numberofdays(suboptical) == numberofdays(orbit) < 0.18
         @test minmaxdates(orbit) == (date(suboptical[1]), date(suboptical[end]))
@@ -269,6 +270,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.9867704701732631, 0.3781890325424674, 0.14094513213009532,
             -0.008773157203087259, -0.00947109649687576, -0.005654229864757284]
         JPL_KEP = [8.198835710815939E-01, 3.962989389356275E-01, 5.807184452352074E+00,
@@ -301,6 +303,7 @@ end
         # Check type
         @test isa(orbit1, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit1) == "2023 DW"
         @test length(suboptical) == nobs(od) == nobs(orbit1) == 43
         @test numberofdays(suboptical) == numberofdays(orbit1) < 2.76
         @test minmaxdates(orbit1) == (date(suboptical[1]), date(suboptical[end]))
@@ -337,6 +340,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (3.1E-01, 4.5E-01, 5.7E-11, 8.2E-12, 6.3E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -373,11 +377,12 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2005 TM173"
         @test length(optical) == nobs(od) == nobs(orbit) == 6
         @test numberofdays(optical) == numberofdays(orbit) < 1.95
         @test minmaxdates(orbit) == (date(optical[1]), date(optical[end]))
@@ -414,6 +419,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [1.0042569058151192, 0.2231639040146286, 0.11513854178693468,
             -0.010824212819531798, 0.017428798232689943, 0.0071046780555307385]
         JPL_KEP = [2.872424697642789E+00, 6.749395051551541E-01, 1.282355986214476E+00,
@@ -458,11 +464,12 @@ end
         # Initial Orbit Determination
         orbit = gaussiod(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2024 MK"
         @test length(suboptical) == nobs(od) == nobs(orbit) == 12
         @test numberofdays(suboptical) == numberofdays(orbit) < 42.8
         @test minmaxdates(orbit) == (date(suboptical[1]), date(suboptical[end]))
@@ -499,6 +506,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.12722461679828806, -0.9466098076903212, -0.4526816007640767,
             0.02048875631534963, -0.00022720097573790754, 0.00321302850930331]
         JPL_KEP = [2.232655272359251E+00, 5.480018648354085E-01, 8.456325272115306E+00,
@@ -538,7 +546,7 @@ end
         # Admissible region
         A = AdmissibleRegion(tracklet, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Zero AdmissibleRegion
         @test iszero(zero(AdmissibleRegion{Float64}))
@@ -686,7 +694,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -697,6 +705,7 @@ end
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2008 EK68"
         @test length(optical) == nobs(od) == nobs(orbit) == 10
         @test numberofdays(optical) == numberofdays(orbit) < 0.05
         @test minmaxdates(orbit) == (date(optical[1]), date(optical[end]))
@@ -733,6 +742,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.9698405495747651, 0.24035304578776012, 0.10288276585828428,
             -0.009512301266159554, -0.01532548565855646, -0.00809464581680694]
         JPL_KEP = [1.484448954296998E+00, 3.966995063832199E-01, 3.961868860866990E+00,
@@ -774,11 +784,12 @@ end
         # Initial Orbit Determination (with outlier rejection)
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2007 VV7"
         @test length(suboptical) == nobs(od) == nobs(orbit) == 18
         @test numberofdays(suboptical) == numberofdays(orbit) < 2.16
         @test minmaxdates(orbit) == (date(suboptical[1]), date(suboptical[end]))
@@ -815,6 +826,7 @@ end
         # @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [0.7673366466815864, 0.6484892781853565, 0.29323267343908294,
             -0.011023343781911974, 0.015392697071667377, 0.006528842022004942]
         JPL_KEP = [1.776244846691859E+00, 4.381984418639090E-01, 7.819612775042287E-01,
@@ -845,6 +857,7 @@ end
         # Check type
         @test isa(orbit1, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit1) == "2007 VV7"
         @test length(optical) == nobs(od) == nobs(orbit1) == 21
         @test numberofdays(optical) == numberofdays(orbit1) < 3.03
         @test minmaxdates(orbit1) == (date(optical[1]), date(optical[end]))
@@ -884,6 +897,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (4.5E-04, 1.2E-02, 1.2E-10, 8.2E-11, 8.3E-11),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -924,7 +938,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -935,6 +949,7 @@ end
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2014 AA"
         @test length(optical) == nobs(od) == nobs(orbit) == 7
         @test numberofdays(optical) == numberofdays(orbit) < 0.05
         @test minmaxdates(orbit) == (date(optical[1]), date(optical[end]))
@@ -971,6 +986,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.1793421909678032, 0.8874121750891107, 0.3841434101167349,
             -0.017557851117612377, -0.005781634223099801, -0.0020075106081869185]
         JPL_KEP = [1.163575955666616E+00, 2.128185264087166E-01, 1.423597471953649E+00,
@@ -1012,11 +1028,12 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2008 TC3"
         @test length(suboptical) == nobs(od) == nobs(orbit) == 18
         @test numberofdays(suboptical) == numberofdays(orbit) < 0.34
         @test minmaxdates(orbit) == (date(suboptical[1]), date(suboptical[end]))
@@ -1053,6 +1070,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [0.9739760787551061, 0.21541704400792083, 0.09401075290627411,
             -0.00789675674941779, 0.0160619782715116, 0.006135361409943397]
         JPL_KEP = [1.273091758414584E+00, 2.870222798582721E-01, 2.341999526552296E+00,
@@ -1085,6 +1103,7 @@ end
         # Check type
         @test isa(orbit1, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit1) == "2008 TC3"
         @test length(suboptical) == nobs(od) == nobs(orbit1) == 97
         @test numberofdays(suboptical) == numberofdays(orbit1) < 0.70
         @test minmaxdates(orbit1) == (date(suboptical[1]), date(suboptical[end]))
@@ -1121,6 +1140,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (1.7E-01, 1.9E-01, 2.2E-07, 1.8E-8, 1.4E-09),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -1187,12 +1207,13 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params; initcond = iodinitcond)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
         @test flag
+        @test designation(orbit) == "2023 QR6"
         @test length(optical) == nobs(od) == nobs(orbit) == 6
         @test numberofdays(optical) == numberofdays(orbit) < 6.22
         @test minmaxdates(orbit) == (date(optical[1]), date(optical[end]))
@@ -1229,6 +1250,7 @@ end
         # @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [8.273613111662440E-01, -8.060979570468877E-01, -6.506021560333630E-01,
                    1.659953139139261E-02, -5.614155804560522E-03, 2.899959983103430E-03]
         JPL_KEP = [2.279881958167905E+00, 7.595854924208774E-01, 3.859999487009846E+01,
@@ -1293,11 +1315,12 @@ end
         # Refine orbit (both optical and radar astrometry)
         orbit1 = orbitdetermination(od1, orbit0, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit1, RadarOrbit{Float64})
         # Astrometry
+        @test designation(orbit1) == "99942"
         @test length(optical) == noptical(od1) == noptical(orbit1) == 24
         @test length(radar) == nradar(od1) == nradar(orbit1) == 5
         @test length(optical) + length(radar) == nobs(od1) == nobs(orbit1) == 24 + 5
@@ -1342,6 +1365,7 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit1, params))
         JPL_CAR = [-5.229992130937651E-01, 8.689454573480734E-01, 3.096174868699621E-01,
             -1.413639580483663E-02, -5.510379552549767E-03, -2.413003153288419E-03]
         JPL_KEP = [9.223295977030230E-01, 1.911190963976789E-01, 3.330797253820763E+00,
@@ -1392,11 +1416,12 @@ end
         # Linkage
         orbit = linkage(od, orbit, params)
 
-        # Values by July 1, 2026
+        # Values by July 2, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
         # Tracklets
+        @test designation(orbit) == "2020 NB1"
         @test length(optical) == nobs(od) == nobs(orbit) == 44
         @test numberofdays(optical) == numberofdays(orbit) < 3766
         @test minmaxdates(orbit) == (date(optical[1]), date(optical[end]))
@@ -1433,6 +1458,7 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
+        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [4.848674283176028E-01, -1.256976941043074E+00, 7.558473824624909E-02,
                    2.837659541627720E-03, 1.669282318693257E-02, 4.630635236479733E-03]
         JPL_KEP = [2.315552902881586E+00, 8.475227263442291E-01, 3.315750642722048E+01,

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -378,7 +378,7 @@ end
         params = Parameters(params; maxsteps = 1)
         sol, tvS, xvS, gvS = NEOs.propagate_root(dynamics, q0, jd0, nyears, params)
 
-        @test JLD2.writeas(typeof(sol)) == TaylorIntegration.TaylorSolutionNSerialization{Float64, 2} 
+        @test JLD2.writeas(typeof(sol)) == TaylorIntegration.TaylorSolutionNSerialization{Float64, 2}
         jldsave("test.jld2"; sol, tvS, xvS, gvS)
         recovered_sol = JLD2.load("test.jld2", "sol")
         recovered_tvS = JLD2.load("test.jld2", "tvS")


### PR DESCRIPTION
This PR introduces a new function `print_mpec_elements` which prints the keplerian elements of an `AbstractOrbit` in the MPEC format.