### PR TITLE
New function `print_mpec`

### DIFF
--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -96,7 +96,7 @@ export leastsquares, leastsquares!, tryls, outlier_rejection!, project, critical
 export variables, designation, epoch, firsttime, lasttime, noptical, nradar, minmaxdates,
        optical, sigmas, snr, keplerian, equinoctial, attributable, uncertaintyparameter,
        absolutemagnitude, diameter, mass, shiftepoch, print_mpec_residuals,
-       print_mpec_elements
+       print_mpec_elements, print_mpec_ephemeris, print_mpec
 export topo2bary, bary2topo, attr2bary, tsaiod
 export mmov, gaussmethod, gaussiod, jtls, issinglearc, initialorbitdetermination,
        orbitdetermination, linkage

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -113,7 +113,7 @@ function print_mpec_residuals(io::IO, x::AbstractOpticalVector,
     @. v[1:L] = mpec_residual(x, y)
     @. v[L+1:end] = ""
     m = reshape(v, Nrows, 3)
-    print(
+    write(
         io,
         "Residuals in seconds of arc\n",
         join(join.(eachrow(m), "   "), '\n'), '\n'

--- a/src/orbitdetermination/abstractorbit/abstractorbit.jl
+++ b/src/orbitdetermination/abstractorbit/abstractorbit.jl
@@ -599,9 +599,7 @@ Print to `io` the keplerian elements of an `orbit` at time `t`
 print_mpec_elements(orbit::AbstractOrbit, params::Parameters, t::Real = epoch(orbit)) =
     print_mpec_elements(stdout, orbit, params, t)
 
-# TO DO:
-# - Use MOID.jl to compute the minimum orbit intersection distance,
-# - Verify that the formulas for P_vec and Q_vec are correct.
+# TO DO: Use MOID.jl to compute the minimum orbit intersection distance
 function print_mpec_elements(io::IO, orbit::AbstractOrbit, params::Parameters,
                              t::Real = epoch(orbit))
     jdt = t + PE.J2000 + ttmtdb(t) / daysec
@@ -619,17 +617,18 @@ function print_mpec_elements(io::IO, orbit::AbstractOrbit, params::Parameters,
     ω = argperi(kep)
     Ω = longascnode(kep)
     P = (2π / yr) * sqrt(a^3 / μ_S)
-    P_vec = [
+    R = Rx(deg2rad(ϵ0_deg))'
+    P_vec = R * [
         cosd(ω)*cosd(Ω) - sind(ω)*sind(Ω)*cosd(i),
         cosd(ω)*sind(Ω) + sind(ω)*cosd(Ω)*cosd(i),
         sind(ω)*sind(i)
     ]
-    Q_vec = [
-        sind(ω)*cosd(Ω) + cosd(ω)*sind(Ω)*cosd(i),
-        cosd(ω)*cosd(Ω)*cosd(i) - sind(ω)*sind(Ω),
+    Q_vec = R * [
+        -sind(ω)*cosd(Ω) - cosd(ω)*sind(Ω)*cosd(i),
+        -sind(ω)*sind(Ω) + cosd(ω)*cosd(Ω)*cosd(i) ,
         cosd(ω)*sind(i)
     ]
-    print(
+    write(
         io,
         "Orbital elements:\n",
         @sprintf("%-56sEarth MOID = %.4f AU\n", designation(orbit), NaN),
@@ -640,6 +639,84 @@ function print_mpec_elements(io::IO, orbit::AbstractOrbit, params::Parameters,
         @sprintf("e%12.7f%6sIncl.%11.5f%5s%+11.8f%5s%+11.8f\n", e, "", i, "", P_vec[3], "", Q_vec[3]),
         @sprintf("P%7.2f%11sH%8.2f%10sG%7.2f%11sU%4d\n", P, "", H, "", G, "", U),
     )
+    return nothing
+end
+
+"""
+    print_mpec_ephemeris([io::IO], orbit, params [, ts])
+
+Print to `io` the geocentric ephemeris of an `orbit` at `ts`,
+a vector of time periods relative to the orbit's epoch
+(default: `-Day(7):Day(1):Day(7)`), in the MPEC format.
+"""
+print_mpec_ephemeris(orbit::AbstractOrbit, params::Parameters) =
+    print_mpec_ephemeris(stdout, orbit, params)
+
+function print_mpec_ephemeris(io::IO, orbit::AbstractOrbit, params::Parameters,
+                              ts::AbstractVector{T} = -Day(7):Day(1):Day(7)) where {T <: Period}
+    @unpack eph_su, eph_ea, slope = params
+    desig = designation(orbit)
+    kep = keplerian(orbit, params)
+    a = semimajoraxis(kep)
+    e = eccentricity(kep)
+    i = inclination(kep)
+    q = a * (1 - e)
+    H = absolutemagnitude(orbit, params)[1]
+    d0 = DateTime(Date(days2dtutc(epoch(orbit))))
+    lines = Vector{String}(undef, length(ts))
+    for i in eachindex(lines)
+        d = d0 + ts[i]
+        t = dtutc2days(d)
+        qs = eph_su(t)[1:3]
+        qe = eph_ea(t)[1:3]
+        qa = ecliptic2equatorial(kep(t + MJD2000))[1:3] + qs
+        qas = qa - qs
+        qae = qa - qe
+        qes = qe - qs
+        das = norm(qas)
+        dae = norm(qae)
+        hms = rad2hms(mod2pi(atan(qae[2], qae[1])))
+        dms = rad2dms(asin(qae[3] / dae))
+        elong = angle(qae, qes)
+        phase = angle(-qae, -qas)
+        V = H + 5 * log10(das * dae) - 2.5 * phase_integral(phase, slope)
+        lines[i] = @sprintf(
+            "%-14s%02d %02d %04.1f %s%02d %02d %02d%3s%6.4f%8.4f%8.1f%8.1f%8.1f\n",
+            Dates.format(d, "yyyy mm dd"), hms[1], hms[2], hms[3],
+            dms[1] ≥ 0 ? "+" : "-", abs(dms[1]), dms[2], dms[3], "",
+            dae, das, rad2deg(elong), rad2deg(phase), V
+        )
+    end
+    write(
+        io,
+        "Ephemeris:\n",
+        @sprintf("%-25sa,e,i = %.2f, %.2f, %d%19sq = %.4f\n", desig, a, e, i, "", q),
+        "Date    TT    R. A. (2000) Decl.     Delta      r    Elong.  Phase     V\n",
+        join(lines)
+    )
+    return nothing
+end
+
+"""
+    print_mpec([io::IO], orbit, params [, ts])
+
+Print to `io` the Minor Planet Electronic Circular (MPEC) corresponding
+to `orbit` with geocentric ephemeris at `ts`, a vector of time periods
+relative to the orbit's epoch (default: `-Day(7):Day(1):Day(7)`).
+"""
+print_mpec(orbit::AbstractOrbit, params::Parameters, ts::AbstractVector{T} =
+    -Day(7):Day(1):Day(7)) where {T <: Period} = print_mpec(stdout, orbit, params, ts)
+
+# TO DO: Print observations in 80-column format at the top of the MPEC
+function print_mpec(io::IO, orbit::AbstractOrbit, params::Parameters,
+                    ts::AbstractVector{T} = -Day(7):Day(1):Day(7)) where {T <: Period}
+    x = IOBuffer()
+    print_mpec_elements(x, orbit, params)
+    print(x, '\n')
+    print_mpec_residuals(x, orbit)
+    print(x, '\n')
+    print_mpec_ephemeris(x, orbit, params, ts)
+    print(io, String(take!(x)))
     return nothing
 end
 

--- a/test/orbitdetermination.jl
+++ b/test/orbitdetermination.jl
@@ -228,7 +228,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -251,7 +251,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 9
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -270,7 +269,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.9867704701732631, 0.3781890325424674, 0.14094513213009532,
             -0.008773157203087259, -0.00947109649687576, -0.005654229864757284]
         JPL_KEP = [8.198835710815939E-01, 3.962989389356275E-01, 5.807184452352074E+00,
@@ -292,6 +290,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 5.4E7 < Ma < Mc < Mb < 6.3E8
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
 
         # Add observations
         suboptical = iodsuboptical(optical, 15)
@@ -321,7 +322,6 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 43
         @test nout(orbit1.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -340,7 +340,6 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (3.1E-01, 4.5E-01, 5.7E-11, 8.2E-12, 6.3E-12),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -356,6 +355,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit1, params)
         @test 6.4E7 < Ma < Mc < Mb < 7.4E8
+        # MPEC
+        @test isnothing(print_mpec(orbit1, params))
+        println()
     end
 
     @testset "Unsafe Gauss Method" begin
@@ -377,7 +379,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -400,7 +402,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 6
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -419,7 +420,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [1.0042569058151192, 0.2231639040146286, 0.11513854178693468,
             -0.010824212819531798, 0.017428798232689943, 0.0071046780555307385]
         JPL_KEP = [2.872424697642789E+00, 6.749395051551541E-01, 1.282355986214476E+00,
@@ -441,6 +441,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 9.4E7 < Ma < Mc < Mb < 1.2E9
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
     end
 
     @testset "Gauss Method with ADAM refinement" begin
@@ -464,7 +467,7 @@ end
         # Initial Orbit Determination
         orbit = gaussiod(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -487,7 +490,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 12
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -506,7 +508,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.12722461679828806, -0.9466098076903212, -0.4526816007640767,
             0.02048875631534963, -0.00022720097573790754, 0.00321302850930331]
         JPL_KEP = [2.232655272359251E+00, 5.480018648354085E-01, 8.456325272115306E+00,
@@ -528,6 +529,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 2.2E9 < Ma < Mc < Mb < 2.8E10
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
     end
 
     @testset "Admissible region" begin
@@ -546,7 +550,7 @@ end
         # Admissible region
         A = AdmissibleRegion(tracklet, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Zero AdmissibleRegion
         @test iszero(zero(AdmissibleRegion{Float64}))
@@ -694,7 +698,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -723,7 +727,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 10
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -742,7 +745,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.9698405495747651, 0.24035304578776012, 0.10288276585828428,
             -0.009512301266159554, -0.01532548565855646, -0.00809464581680694]
         JPL_KEP = [1.484448954296998E+00, 3.966995063832199E-01, 3.961868860866990E+00,
@@ -764,6 +766,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 4.3E4 < Ma < Mc < Mb < 5.2E5
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
     end
 
     @testset "Outlier Rejection" begin
@@ -784,7 +789,7 @@ end
         # Initial Orbit Determination (with outlier rejection)
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -807,7 +812,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 16
         @test nout(orbit.ores) == 2
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -826,7 +830,6 @@ end
         # @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [0.7673366466815864, 0.6484892781853565, 0.29323267343908294,
             -0.011023343781911974, 0.015392697071667377, 0.006528842022004942]
         JPL_KEP = [1.776244846691859E+00, 4.381984418639090E-01, 7.819612775042287E-01,
@@ -848,6 +851,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 2.2E6 < Ma < Mc < Mb < 2.8E7
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
 
         # Add remaining observations
         NEOs.update!(od, optical)
@@ -875,7 +881,6 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 19
         @test nout(orbit1.ores) == 2
-        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -897,7 +902,6 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (4.5E-04, 1.2E-02, 1.2E-10, 8.2E-11, 8.3E-11),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -913,6 +917,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit1, params)
         @test 2.2E6 < Ma < Mc < Mb < 2.7E7
+        # MPEC
+        @test isnothing(print_mpec(orbit1, params))
+        println()
     end
 
     @testset "Interesting NEOs" begin
@@ -938,7 +945,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Curvature
         C, Γ_C = curvature(optical, od.weights)
@@ -967,7 +974,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 7
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -986,7 +992,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [-0.1793421909678032, 0.8874121750891107, 0.3841434101167349,
             -0.017557851117612377, -0.005781634223099801, -0.0020075106081869185]
         JPL_KEP = [1.163575955666616E+00, 2.128185264087166E-01, 1.423597471953649E+00,
@@ -1008,6 +1013,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 7.0E3 < Ma < Mc < Mb < 8.1E4
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
 
         # 2008 TC3 entered the Earth's atmosphere around October 7, 2008, 02:46 UTC
 
@@ -1028,7 +1036,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1051,7 +1059,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 18
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1070,7 +1077,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [0.9739760787551061, 0.21541704400792083, 0.09401075290627411,
             -0.00789675674941779, 0.0160619782715116, 0.006135361409943397]
         JPL_KEP = [1.273091758414584E+00, 2.870222798582721E-01, 2.341999526552296E+00,
@@ -1092,6 +1098,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 1.3E4 < Ma < Mc < Mb < 1.7E5
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
 
         # Add observations
         suboptical = iodsuboptical(optical, 10)
@@ -1121,7 +1130,6 @@ end
         # Vector of residuals
         @test notout(orbit1.ores) == 97
         @test nout(orbit1.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -1140,7 +1148,6 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit1, params))
         jpl_compatibility_tests(orbit1, params, (1.7E-01, 1.9E-01, 2.2E-07, 1.8E-8, 1.4E-09),
                                 JPL_CAR, JPL_KEP, JPL_EQN, JPL_ATTR)
         # Absolute magnitude
@@ -1160,6 +1167,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit1, params)
         @test 1.4E4 < Ma < Mc < Mb < 1.7E5
+        # MPEC
+        @test isnothing(print_mpec(orbit1, params))
+        println()
     end
 
     @testset "research/2025CMDA/orbitdetermination.jl" begin
@@ -1207,7 +1217,7 @@ end
         # Initial Orbit Determination
         orbit = initialorbitdetermination(od, params; initcond = iodinitcond)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1231,7 +1241,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 6
         @test nout(orbit.ores) == 0
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1250,7 +1259,6 @@ end
         # @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [8.273613111662440E-01, -8.060979570468877E-01, -6.506021560333630E-01,
                    1.659953139139261E-02, -5.614155804560522E-03, 2.899959983103430E-03]
         JPL_KEP = [2.279881958167905E+00, 7.595854924208774E-01, 3.859999487009846E+01,
@@ -1272,6 +1280,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 2.2E11 < Ma < Mc < Mb < 2.8E12
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
     end
 
     @testset "Radar astrometry" begin
@@ -1315,7 +1326,7 @@ end
         # Refine orbit (both optical and radar astrometry)
         orbit1 = orbitdetermination(od1, orbit0, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit1, RadarOrbit{Float64})
@@ -1346,7 +1357,6 @@ end
         @test notout(orbit1.rres) == 5
         @test nout(orbit1.ores) == 0
         @test nout(orbit1.rres) == 0
-        @test isnothing(print_mpec_residuals(orbit1))
         # Least squares fit
         @test isa(string(orbit1.fit), String)
         @test orbit1.fit.success
@@ -1365,7 +1375,6 @@ end
         @test issorted(orbit1.Qs, rev = true)
         @test orbit1.Qs[end] == nrms(orbit1)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit1, params))
         JPL_CAR = [-5.229992130937651E-01, 8.689454573480734E-01, 3.096174868699621E-01,
             -1.413639580483663E-02, -5.510379552549767E-03, -2.413003153288419E-03]
         JPL_KEP = [9.223295977030230E-01, 1.911190963976789E-01, 3.330797253820763E+00,
@@ -1387,6 +1396,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit1, params)
         @test 1.0E11 < Ma < Mc < Mb < 1.4E12
+        # MPEC
+        @test isnothing(print_mpec(orbit1, params))
+        println()
     end
 
     @testset "Linkage" begin
@@ -1416,7 +1428,7 @@ end
         # Linkage
         orbit = linkage(od, orbit, params)
 
-        # Values by July 2, 2026
+        # Values by July 9, 2026
 
         # Check type
         @test isa(orbit, OpticalOrbit{Float64})
@@ -1439,7 +1451,6 @@ end
         # Vector of residuals
         @test notout(orbit.ores) == 43
         @test nout(orbit.ores) == 1
-        @test isnothing(print_mpec_residuals(orbit))
         # Least squares fit
         @test isa(string(orbit.fit), String)
         @test orbit.fit.success
@@ -1458,7 +1469,6 @@ end
         @test issorted(orbit.Qs, rev = true)
         @test orbit.Qs[end] == nrms(orbit)
         # Compatibility with JPL
-        @test isnothing(print_mpec_elements(orbit, params))
         JPL_CAR = [4.848674283176028E-01, -1.256976941043074E+00, 7.558473824624909E-02,
                    2.837659541627720E-03, 1.669282318693257E-02, 4.630635236479733E-03]
         JPL_KEP = [2.315552902881586E+00, 8.475227263442291E-01, 3.315750642722048E+01,
@@ -1480,6 +1490,9 @@ end
         Ma, Mb = minmax(mass(2_600, Da), mass(2_600, Db))
         Mc = mass(orbit, params)
         @test 1.0E+10 < Ma < Mc < Mb < 1.3E+11
+        # MPEC
+        @test isnothing(print_mpec(orbit, params))
+        println()
     end
 
 end


### PR DESCRIPTION
This PR introduces a new function `print_mpec` to print the Minor Planet Electronic Circular (MPEC) corresponding to an `AbstractOrbit`, which relies on the `print_mpec_*` functions introduced in previous commits.