### PR TITLE
Make time of day an internal field of all optical astrometry types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
-version = "0.28.1"
+version = "0.29.0"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
 
 [deps]

--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -65,8 +65,9 @@ export ZeroDebiasing, SourceDebiasing, Farnocchia15, Eggl20
 export numberofdays, unpacknum, packnum, unpackdesig, packdesig,
        fetch_designation_information, fetch_mpec_information
 export date, measure, observatory, rms, debias, corr, ra, dec, mag, band, catalogue,
-       cataloguecode, observatorycode, vconversion, isdiscovery, isdeprecated, trackletid,
-       frequency, residual, weight, weights, isoutlier, nout, notout, notoutobs
+       cataloguecode, observatorycode, vconversion, timeofday, isdiscovery, isdeprecated,
+       trackletid, frequency, residual, weight, weights, isoutlier, nout, notout,
+       notoutobs
 export obsposECEF, obsposvelECI
 export update_catalogues_mpc, search_catalogue_code, search_catalogue_value
 export update_observatories_mpc, search_observatory_code, fetch_observatory_information

--- a/src/astrometry/abstractastrometry.jl
+++ b/src/astrometry/abstractastrometry.jl
@@ -104,6 +104,7 @@ mag(x::AbstractOpticalAstrometry) = x.mag
 cataloguecode(x::AbstractOpticalAstrometry) = catalogue(x).code
 vconversion(x::AbstractOpticalAstrometry) = band(x).v_conversion
 observatorycode(x::AbstractOpticalAstrometry) = observatory(x).code
+timeofday(x::AbstractOpticalAstrometry) = x.timeofday
 
 """
     AbstractRadarAstrometry{T} <: AbstractAstrometryObservation{T}

--- a/src/astrometry/opticalades.jl
+++ b/src/astrometry/opticalades.jl
@@ -109,6 +109,8 @@ An optical astrometric observation in the Minor Planet Center ADES format.
     remarks::String
     deprecated::String
     source::String
+    # Internal
+    timeofday::TimeOfDay
 end
 
 # AbstractAstrometryObservation interface
@@ -194,10 +196,10 @@ OpticalADES(r::DataFrameRow) = OpticalADES{Float64}(
     r.rmstime, r.ra, r.dec, r.rastar, r.decstar, r.deltara, r.deltadec,
     r.rmsra, r.rmsdec, r.rmscorr, r.astcat, r.mag, r.rmsmag, r.band,
     r.photcat, r.ref, r.disc, r.subfmt, r.prectime, r.precra, r.precdec,
-    r.unctime, r.notes, r.remarks, r.deprecated, r.source
+    r.unctime, r.notes, r.remarks, r.deprecated, r.source, r.timeofday
 )
 
-function parse_optical_ades(text::String)
+function parse_optical_ades(text::String; eop::EOPIAU = EOP_IAU2000A)
     # Parse XML
     node = parse(LazyNode, text)
     # Locate the root <ades> element and its observation elements by node type:
@@ -242,7 +244,9 @@ function parse_optical_ades(text::String)
         df.ra[i] = df.rastar[i] + df.deltara[i] / cos(df.dec[i])
     end
     # Source string
-    df.source = XML.write.(obs)
+    df.source .= XML.write.(obs)
+    # Time of day
+    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.stn, df.obstime)
     # Parse observations
     optical = OpticalADES.(eachrow(df))
 
@@ -250,49 +254,59 @@ function parse_optical_ades(text::String)
 end
 
 """
-    fetch_optical_ades(id, source)
+    fetch_optical_ades(id, source; kwargs...)
 
 Return the optical astrometry of minor body `id` in the Minor Planet Center
 ADES format. The `source` of the observations can be either `MPC` or `NEOCP`.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 
 !!! reference
     The Minor Planet Center observations APIs are described at:
     - https://docs.minorplanetcenter.net/mpc-ops-docs/apis/get-obs/
     - https://docs.minorplanetcenter.net/mpc-ops-docs/apis/get-obs-neocp/
 """
-function fetch_optical_ades(id::AbstractString, ::Type{MPC})
+function fetch_optical_ades(id::AbstractString, ::Type{MPC};
+                            eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(MPC; mode = 2, id = id, format = "XML")
     # Parse JSON
     dict = JSON.parse(text)
     # Parse observations
-    optical = parse_optical_ades(dict[1]["XML"])
+    optical = parse_optical_ades(dict[1]["XML"]; eop)
 
     return optical
 end
 
-function fetch_optical_ades(id::AbstractString, ::Type{NEOCP})
+function fetch_optical_ades(id::AbstractString, ::Type{NEOCP};
+                            eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(NEOCP; mode = 1, id = id, format = "XML")
     # Parse JSON
     dict = JSON.parse(text)
     # Parse observations
-    optical = parse_optical_ades(dict[1]["XML"])
+    optical = parse_optical_ades(dict[1]["XML"]; eop)
 
     return optical
 end
 
 """
-    read_optical_ades(filename)
+    read_optical_ades(filename; kwargs...)
 
 Read from `filename` a vector of optical astrometry in the Minor Planet
 Center ADES format.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 """
-function read_optical_ades(filename::AbstractString)
+function read_optical_ades(filename::AbstractString; eop::EOPIAU = EOP_IAU2000A)
     # Read file
     text = read(filename, String)
     # Parse observations
-    optical = parse_optical_ades(text)
+    optical = parse_optical_ades(text; eop)
 
     return optical
 end

--- a/src/astrometry/opticalmpc80.jl
+++ b/src/astrometry/opticalmpc80.jl
@@ -82,6 +82,8 @@ An optical astrometric observation in Minor Planet Center 80-column format.
     info2::String
     observatory::ObservatoryMPC{T}
     source::String
+    # Internal
+    timeofday::TimeOfDay
 end
 
 # AbstractAstrometryObservation interface
@@ -146,11 +148,12 @@ function mpc80parse(name, ::Type{T}, x) where {T <: Real}
 end
 
 OpticalMPC80(r::DataFrameRow) = OpticalMPC80{Float64}(
-    r.number, r.desig, r.discovery, r.note1, r.note2, r.date, r.ra, r.dec,
-    r.info1, r.mag, r.band, r.catalogue, r.info2, r.observatory, r.source
+    r.number, r.desig, r.discovery, r.note1, r.note2, r.date, r.ra,
+    r.dec, r.info1, r.mag, r.band, r.catalogue, r.info2, r.observatory,
+    r.source, r.timeofday
 )
 
-function parse_optical_mpc80(text::AbstractString)
+function parse_optical_mpc80(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
     # File reader
     reader = MPC80FileReader(text)
     L = length(reader.optical)
@@ -186,7 +189,9 @@ function parse_optical_mpc80(text::AbstractString)
         df.observatory[i] = ObservatoryMPC(obs; frame, coords)
     end
     # Source string
-    df.source = reader.optical
+    df.source .= reader.optical
+    # Time of day
+    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.observatory, df.date)
     # Parse observations
     optical = OpticalMPC80.(eachrow(df))
     # Eliminate repeated entries
@@ -198,35 +203,41 @@ function parse_optical_mpc80(text::AbstractString)
 end
 
 """
-    fetch_optical_mpc80(id, source)
+    fetch_optical_mpc80(id, source; kwargs...)
 
 Return the optical astrometry of minor body `id` in the Minor Planet Center
 80-column format. The `source` of the observations can be either `MPC` or
 `NEOCP`.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 
 !!! reference
     The Minor Planet Center observations APIs are described at:
     - https://docs.minorplanetcenter.net/mpc-ops-docs/apis/get-obs/
     - https://docs.minorplanetcenter.net/mpc-ops-docs/apis/get-obs-neocp/
 """
-function fetch_optical_mpc80(id::AbstractString, ::Type{MPC})
+function fetch_optical_mpc80(id::AbstractString, ::Type{MPC};
+                             eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(MPC; mode = 2, id = id, format = "OBS80")
     # Parse JSON
     dict = JSON.parse(text)
     # Parse observations
-    optical = parse_optical_mpc80(dict[1]["OBS80"])
+    optical = parse_optical_mpc80(dict[1]["OBS80"]; eop)
 
     return optical
 end
 
-function fetch_optical_mpc80(id::AbstractString, ::Type{NEOCP})
+function fetch_optical_mpc80(id::AbstractString, ::Type{NEOCP};
+                             eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(NEOCP; mode = 1, id = id, format = "OBS80")
     # Parse JSON
     dict = JSON.parse(text)
     # Parse observations
-    optical = parse_optical_mpc80(dict[1]["OBS80"])
+    optical = parse_optical_mpc80(dict[1]["OBS80"]; eop)
 
     return optical
 end
@@ -234,16 +245,20 @@ end
 # Read / write
 
 """
-    read_optical_mpc80(filename)
+    read_optical_mpc80(filename; kwargs...)
 
 Read from `filename` a vector of optical astrometry in the Minor Planet
 Center 80-column format.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 """
-function read_optical_mpc80(filename::AbstractString)
+function read_optical_mpc80(filename::AbstractString; eop::EOPIAU = EOP_IAU2000A)
     # Read file
     text = read(filename, String)
     # Parse observations
-    optical = parse_optical_mpc80(text)
+    optical = parse_optical_mpc80(text; eop)
 
     return optical
 end

--- a/src/astrometry/opticalrwo.jl
+++ b/src/astrometry/opticalrwo.jl
@@ -158,6 +158,8 @@ An optical astrometric observation in the RWO format.
     sel_M::Int
     source::String
     header::String
+    # Internal
+    timeofday::TimeOfDay
 end
 
 # AbstractAstrometryObservation interface
@@ -233,10 +235,10 @@ OpticalRWO(r::DataFrameRow) = OpticalRWO{Float64}(
     r.design, r.K, r.T, r.N, r.date, r.date_accuracy, r.ra, r.ra_accuracy,
     r.ra_rms, r.ra_flag, r.ra_bias, r.ra_resid, r.dec, r.dec_accuracy, r.dec_rms,
     r.dec_flag, r.dec_bias, r.dec_resid, r.mag, r.mag_band, r.mag_rms, r.mag_resid,
-    r.catalogue, r.observatory, r.chi, r.sel_A, r.sel_M, r.source, r.header
+    r.catalogue, r.observatory, r.chi, r.sel_A, r.sel_M, r.source, r.header, r.timeofday
 )
 
-function parse_optical_rwo(text::AbstractString)
+function parse_optical_rwo(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
     # File reader
     reader = RWOFileReader(text)
     L = length(reader.optical)
@@ -274,9 +276,11 @@ function parse_optical_rwo(text::AbstractString)
         df.observatory[i] = ObservatoryMPC(obs; frame, coords)
     end
     # Source string
-    df.source = reader.optical
+    df.source .= reader.optical
     # File header
     df.header .= reader.header
+    # Time of day
+    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.observatory, df.date)
     # Parse observations
     optical = OpticalRWO.(eachrow(df))
     # Eliminate repeated entries
@@ -288,29 +292,35 @@ function parse_optical_rwo(text::AbstractString)
 end
 
 """
-    fetch_optical_rwo(id, source)
+    fetch_optical_rwo(id, source; kwargs...)
 
 Return the optical astrometry of minor body `id` in the RWO format.
 The `source` of the observations can be either `NEOCC` or `NEODyS2`.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 
 !!! reference
     The NEOCC observations API is described at:
     - https://neo.ssa.esa.int/computer-access
 """
-function fetch_optical_rwo(id::AbstractString, ::Type{NEOCC})
+function fetch_optical_rwo(id::AbstractString, ::Type{NEOCC};
+                           eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(NEOCC; id = replace(id, " " => ""))
     # Parse observations
-    optical = parse_optical_rwo(text)
+    optical = parse_optical_rwo(text; eop)
 
     return optical
 end
 
-function fetch_optical_rwo(id::AbstractString, ::Type{NEODyS2})
+function fetch_optical_rwo(id::AbstractString, ::Type{NEODyS2};
+                           eop::EOPIAU = EOP_IAU2000A)
     # Get and parse HTTP response
     text = fetch_http_text(NEODyS2; id = replace(id, " " => ""))
     # Parse observations
-    optical = parse_optical_rwo(text)
+    optical = parse_optical_rwo(text; eop)
 
     return optical
 end
@@ -318,15 +328,19 @@ end
 # Read / write
 
 """
-    read_optical_rwo(filename)
+    read_optical_rwo(filename; kwargs...)
 
 Read from `filename` a vector of optical astrometry in the RWO format.
+
+# Keyword arguments
+
+- `eop::EOPIAU`: Earth Orientation Parameters (default: `EOP_IAU2000A`).
 """
-function read_optical_rwo(filename::AbstractString)
+function read_optical_rwo(filename::AbstractString; eop::EOPIAU = EOP_IAU2000A)
     # Read file
     text = read(filename, String)
     # Parse observations
-    optical = parse_optical_rwo(text)
+    optical = parse_optical_rwo(text; eop)
 
     return optical
 end

--- a/src/astrometry/opticaltracklet.jl
+++ b/src/astrometry/opticaltracklet.jl
@@ -1,13 +1,13 @@
 """
     OpticalTracklet{T} <: AbstractOpticalAstrometry{T}
 
-The averague of a set of optical astrometry taken by the
-same observatory on the same night.
+The average of a set of optical astrometry taken by the
+same observatory on the same time of day.
 
 # Fields
 
 - `observatory::ObservatoryMPC{T}`: observing station.
-- `night::TimeOfDay`: night of observation.
+- `timeofday::TimeOfDay`: observation time of day.
 - `date::DateTime`: mean date of observation.
 - `ra::T`: mean right ascension [rad].
 - `dec::T`: mean declination [rad].
@@ -20,7 +20,7 @@ same observatory on the same night.
 """
 @auto_hash_equals fields = (date, ra, dec, observatory) struct OpticalTracklet{T} <: AbstractOpticalAstrometry{T}
     observatory::ObservatoryMPC{T}
-    night::TimeOfDay
+    timeofday::TimeOfDay
     date::DateTime
     ra::T
     dec::T
@@ -121,7 +121,7 @@ end
 # Outer constructor
 function OpticalTracklet(x::NamedTuple)
     # Unpack
-    @unpack date, ra, dec, observatory, mag, night, indices = x
+    @unpack date, ra, dec, observatory, mag, timeofday, indices = x
     # Number of observations
     nobs = minimum(length, x)
     # Zero or one observations
@@ -129,7 +129,7 @@ function OpticalTracklet(x::NamedTuple)
         throw(ArgumentError("Zero observations do not constitute a tracklet"))
     elseif isone(nobs)
         return OpticalTracklet(
-            observatory[1], night[1], date[1], ra[1], dec[1],
+            observatory[1], timeofday[1], date[1], ra[1], dec[1],
             zero(ra[1]), zero(dec[1]), mag[1], nobs, collect(indices)
         )
     end
@@ -172,7 +172,7 @@ function OpticalTracklet(x::NamedTuple)
     v_α = polymodel(t_mean, diffcoeffs(ra_coef))
     v_δ = polymodel(t_mean, diffcoeffs(dec_coef))
 
-    return OpticalTracklet(observatory[i], night[i], d_mean, α, δ, v_α, v_δ,
+    return OpticalTracklet(observatory[i], timeofday[i], d_mean, α, δ, v_α, v_δ,
                            h, nobs, collect(indices))
 end
 
@@ -180,7 +180,7 @@ end
     reduce_tracklets(::AbstractOpticalVector)
 
 Return a vector of optical tracklets where each element corresponds to a
-batch of observations taken by the same observatory on the same night.
+batch of observations taken by the same observatory on the same time of day.
 The reduction is performed via polynomial regression.
 """
 reduce_tracklets
@@ -193,14 +193,14 @@ for O in nameof.(subtypes(AbstractOpticalAstrometry))
             df = DataFrame(
                 date = date.(optical), ra = ra.(optical), dec = dec.(optical),
                 observatory = observatory.(optical), mag = mag.(optical),
-                night = tmap(TimeOfDay, TimeOfDay, optical), trkid = trackletid.(optical),
+                timeofday = timeofday.(optical), trkid = trackletid.(optical),
                 indices = eachindex(optical)
             )
             # Group by ...
             if hasfield($O, :trkid)
                 gdf = groupby(df, [:trkid])
             else
-                gdf = groupby(df, [:observatory, :night])
+                gdf = groupby(df, [:observatory, :timeofday])
             end
             # Reduce tracklets
             cdf = combine(gdf, AsTable(:) => OpticalTracklet => :tracklets; threads)

--- a/src/astrometry/sources.jl
+++ b/src/astrometry/sources.jl
@@ -164,6 +164,7 @@ astrometrydefault(::Type{String}) = ""
 astrometrydefault(::Type{Bool}) = false
 astrometrydefault(::Type{DateTime}) = DateTime(2000, 1, 1)
 astrometrydefault(::Type{T}) where {T <: Real} = T(NaN)
+astrometrydefault(::Type{TimeOfDay}) = unknowntod()
 astrometrydefault(::Type{CatalogueMPC}) = unknowncat()
 astrometrydefault(::Type{ObservatoryMPC{T}}) where {T <: Real} = unknownobs(T)
 astrometrydefault(::Type{MagnitudeBandMPC{T}}) where {T <: Real} = unknownband(T)

--- a/src/astrometry/topocentric.jl
+++ b/src/astrometry/topocentric.jl
@@ -24,18 +24,20 @@ isnight(x::TimeOfDay) = x.light == :night
 issatellite(x::TimeOfDay) = x.light == :satellite
 isgeocentric(x::TimeOfDay) = x.light == :geocentric
 
+isunknown(x::TimeOfDay) = x.light == :unknown
+unknowntod() = TimeOfDay(:unknown, DateTime(2000, 1, 1, 12), DateTime(2000, 1, 1, 12), 0)
+
 # Print method for TimeOfDay
 function show(io::IO, m::TimeOfDay)
     print(io, uppercasefirst(string(m.light)), " from ", Date(m.start), " to ",
         Date(m.stop), " at UTC", @sprintf("%+d", m.utc))
 end
 
-# Constructors
-TimeOfDay(x::AbstractOpticalAstrometry; eop::EOPIAU = EOP_IAU2000A) =
-    TimeOfDay(observatory(x), date(x); eop)
-
+# Constructor
 function TimeOfDay(observatory::ObservatoryMPC, date::DateTime; eop::EOPIAU = EOP_IAU2000A)
-    if isgeocentric(observatory)
+    if !(DateTime(2000, 1, 1, 12) ≤ date ≤ DateTime(2100, 1, 1, 12))
+        return unknowntod()
+    elseif  isgeocentric(observatory)
         return TimeOfDay(:geocentric, Date(date), Date(date), 0)
     elseif issatellite(observatory) || isoccultation(observatory)
         return TimeOfDay(:satellite, date, date, 0)

--- a/src/astrometry/weightingscheme.jl
+++ b/src/astrometry/weightingscheme.jl
@@ -200,9 +200,9 @@ end
 # https://doi.org/10.1016/j.icarus.2017.05.021
 function rexveres17(optical::AbstractOpticalVector{T}) where {T <: Real}
     # Construct DataFrame
-    df = DataFrame(observatory = observatory.(optical), TimeOfDay = TimeOfDay.(optical))
-    # Group by observatory and TimeOfDay
-    gdf = groupby(df, [:observatory, :TimeOfDay])
+    df = DataFrame(observatory = observatory.(optical), timeofday = timeofday.(optical))
+    # Group by observatory and timeofday
+    gdf = groupby(df, [:observatory, :timeofday])
     # Number of observations per tracklet
     cdf = combine(gdf, nrow)
     # Count observations in each group

--- a/test/optical.jl
+++ b/test/optical.jl
@@ -486,13 +486,13 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
 
     @testset "Topocentric" begin
 
-        using NEOs: TimeOfDay, isday, isnight, issatellite, isgeocentric,
-              sunriseset, obsposECEF, obsposvelECI, parse_optical_ades
+        using NEOs: isday, isnight, issatellite, isgeocentric, sunriseset,
+                    obsposECEF, obsposvelECI, parse_optical_ades
 
         # TimeOfDay
-        light1 = TimeOfDay.(optical1)
-        light2 = TimeOfDay.(optical2)
-        light3 = TimeOfDay.(optical3)
+        light1 = timeofday.(optical1)
+        light2 = timeofday.(optical2)
+        light3 = timeofday.(optical3)
 
         mask1, mask2, mask3 = @. isday(light1), isday(light2), isday(light3)
         @test count(mask1) == count(mask2) == count(mask3) == 0


### PR DESCRIPTION
Following a suggestion by @PerezHz, this PR makes the time of day (previously referred to as the observation night) an internal field of all the optical astrometry types. Thus, the time of day is now computed only once when the astrometry is loaded and not every time tracklets are assembled.