### PR TITLE
Manually rejected observations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NEOs"
 uuid = "b41c07a2-2abb-11e9-070a-c3c1b239e7df"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
 
 [deps]

--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -64,10 +64,10 @@ export UniformWeights, SourceWeights, Veres17
 export ZeroDebiasing, SourceDebiasing, Farnocchia15, Eggl20
 export numberofdays, unpacknum, packnum, unpackdesig, packdesig,
        fetch_designation_information, fetch_mpec_information
-export date, measure, observatory, rms, debias, corr, ra, dec, mag, band, catalogue,
+export date, measure, observatory, rms, debias, ra, dec, mag, band, catalogue,
        cataloguecode, observatorycode, vconversion, timeofday, isdiscovery, isdeprecated,
-       trackletid, frequency, residual, weight, weights, isoutlier, setoutlier, setoutlier!,
-       nout, notout, notoutobs
+       trackletid, frequency, residual, weight, weights, corr, corrs, isoutlier, outliers,
+       setoutlier, setoutlier!, nout, notout, notoutobs
 export obsposECEF, obsposvelECI
 export update_catalogues_mpc, search_catalogue_code, search_catalogue_value
 export update_observatories_mpc, search_observatory_code, fetch_observatory_information

--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -66,8 +66,8 @@ export numberofdays, unpacknum, packnum, unpackdesig, packdesig,
        fetch_designation_information, fetch_mpec_information
 export date, measure, observatory, rms, debias, corr, ra, dec, mag, band, catalogue,
        cataloguecode, observatorycode, vconversion, timeofday, isdiscovery, isdeprecated,
-       trackletid, frequency, residual, weight, weights, isoutlier, nout, notout,
-       notoutobs
+       trackletid, frequency, residual, weight, weights, isoutlier, setoutlier, setoutlier!,
+       nout, notout, notoutobs
 export obsposECEF, obsposvelECI
 export update_catalogues_mpc, search_catalogue_code, search_catalogue_value
 export update_observatories_mpc, search_observatory_code, fetch_observatory_information

--- a/src/astrometry/astrometry.jl
+++ b/src/astrometry/astrometry.jl
@@ -14,10 +14,9 @@ include("opticalrwo.jl")
 include("opticalades.jl")
 include("opticaltracklet.jl")
 include("computeradec.jl")
-include("opticalresidual.jl")
 include("weightingscheme.jl")
 include("debiasingscheme.jl")
-
+include("opticalresidual.jl")
 """
     read_optical_astrometry(filename; format = :auto)
 

--- a/src/astrometry/debiasingscheme.jl
+++ b/src/astrometry/debiasingscheme.jl
@@ -6,15 +6,20 @@ Supertype for the optical astrometry debiasing schemes interface.
 Every debiasing scheme `D{T}` must:
 - be a mutable subtype of `AbstractDebiasingScheme{T}`,
 - implement a `D(::AbstractOpticalVector{T})` constructor,
-- override `debias(::D)`,
-- override `getid(::D)`,
+- override `getid(::D)` and `debias(::D)`.
 - override `update!(::D{T}, ::AbstractOpticalVector{T})`.
 """
 abstract type AbstractDebiasingScheme{T} <: AbstractAstrometryErrorModel{T} end
 
+# AbstractDebiasingScheme interface
+nobs(x::AbstractDebiasingScheme) = length(debias(x))
+
+debias(x::AbstractDebiasingScheme, i::Int) = debias(x)[i]
+debias(x::AbstractDebiasingScheme, i::AbstractVector{Int}) = view(debias(x), i)
+
 # Print method for AbstractDebiasingScheme
 show(io::IO, x::AbstractDebiasingScheme) = print(io, getid(x),
-    " debiasing scheme with ", length(debias(x)), " observations")
+    " debiasing scheme with ", nobs(x), " observations")
 
 """
     ZeroDebiasing{T} <: AbstractDebiasingScheme{T}
@@ -30,11 +35,9 @@ function ZeroDebiasing(optical::AbstractOpticalVector{T}) where {T <: Real}
     return ZeroDebiasing{T}([(zero(T), zero(T)) for _ in eachindex(optical)])
 end
 
-# Override debias
-debias(x::ZeroDebiasing) = x.debias
-
-# Override getid
+# Override getid and debias
 getid(::ZeroDebiasing) = "Zero"
+debias(x::ZeroDebiasing) = x.debias
 
 # Override update!
 function update!(x::ZeroDebiasing{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
@@ -56,11 +59,9 @@ function SourceDebiasing(optical::AbstractOpticalVector{T}) where {T <: Real}
     return SourceDebiasing{T}(debias.(optical))
 end
 
-# Override debias
-debias(x::SourceDebiasing) = x.debias
-
-# Override getid
+# Override getid and debias
 getid(::SourceDebiasing) = "Source"
+debias(x::SourceDebiasing) = x.debias
 
 # Override update!
 function update!(x::SourceDebiasing{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
@@ -92,11 +93,9 @@ function Farnocchia15(optical::AbstractOpticalVector{T}) where {T <: Real}
     return Farnocchia15{T}(debias, catcodes, truth, resol, table)
 end
 
-# Override debias
-debias(x::Farnocchia15) = x.debias
-
-# Override getid
+# Override getid and debias
 getid(::Farnocchia15) = "Farnocchia et al. (2015)"
+debias(x::Farnocchia15) = x.debias
 
 # Override update!
 function update!(x::Farnocchia15{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
@@ -130,11 +129,9 @@ function Eggl20(optical::AbstractOpticalVector{T}, hires::Bool = false) where {T
     return Eggl20{T}(debias, hires, catcodes, truth, resol, table)
 end
 
-# Override debias
-debias(x::Eggl20) = x.debias
-
-# Override getid
+# Override getid and debias
 getid(x::Eggl20) = string("Eggl et al. (2020)", x.hires ? " [high resolution]" : "")
+debias(x::Eggl20) = x.debias
 
 # Override update!
 function update!(x::Eggl20{T}, optical::AbstractOpticalVector{T}) where {T <: Real}

--- a/src/astrometry/opticalades.jl
+++ b/src/astrometry/opticalades.jl
@@ -129,6 +129,7 @@ trackletid(x::OpticalADES) = x.trkid
 isdiscovery(x::OpticalADES) = !isempty(x.disc)
 
 isdeprecated(x::OpticalADES) = !isempty(x.deprecated)
+isoutlier(x::OpticalADES) = isdeprecated(x) || abs(corr(x)) ≥ 1
 
 function designation(x::OpticalADES)
     # If there is no number, use temporary designation

--- a/src/astrometry/opticalmpc80.jl
+++ b/src/astrometry/opticalmpc80.jl
@@ -100,6 +100,7 @@ trackletid(x::OpticalMPC80) = ""
 isdiscovery(x::OpticalMPC80) = x.discovery == '*'
 
 isdeprecated(x::OpticalMPC80) = x.note2 == 'X'
+isoutlier(x::OpticalMPC80) = isdeprecated(x)
 
 function designation(x::OpticalMPC80)
     if isempty(x.number)

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -216,11 +216,11 @@ function init_optical_residuals(
     w8s = weights(wsm, idxs)
     bias = debias(dsm, idxs)
     korrs = corrs(wsm, idxs)
-    outliers = outliers(wsm, idxs)
+    outs = outliers(wsm, idxs)
     res = Vector{OpticalResidual{T, U}}(undef, length(idxs))
     for i in eachindex(res)
         res[i] = OpticalResidual{T, U}(zero(U), zero(U), w8s[i]..., bias[i]...,
-                                       korrs[i], outliers[i])
+                                       korrs[i], outs[i])
     end
     return res
 end

--- a/src/astrometry/opticalresidual.jl
+++ b/src/astrometry/opticalresidual.jl
@@ -55,6 +55,8 @@ wdec(x::OpticalResidual) = x.wdec
 dra(x::OpticalResidual) = x.dra
 ddec(x::OpticalResidual) = x.ddec
 corr(x::OpticalResidual) = x.corr
+setoutlier(x::OpticalResidual{T, U}, y::Bool) where {T, U} = OpticalResidual{T, U}(
+    ra(x), dec(x), wra(x), wdec(x), dra(x), ddec(x), corr(x), y)
 
 # Definition of zero OpticalResidual
 zero(::Type{OpticalResidual{T, U}}) where {T, U} = OpticalResidual{T, U}(
@@ -202,29 +204,29 @@ function anglediff(x::Number, y::Number)
     end
 end
 
+# Initialize vector of optical residuals
 function init_optical_residuals(
-        ::Type{U}, optical::AbstractOpticalVector{T}, w8s::AbstractVector{NTuple{2, T}},
-        bias::AbstractVector{NTuple{2, T}}, corrs::AbstractVector{T},
-        outliers::AbstractVector{Bool}
+        ::Type{U},
+        wsm::AbstractWeightingScheme{T},
+        dsm::AbstractDebiasingScheme{T},
+        idxs::AbstractVector{Int} = 1:nobs(wsm)
     ) where {T <: Real, U <: Number}
-    # Check consistency between arrays
-    @assert length(optical) == length(w8s) == length(bias) == length(outliers)
-    # Initialize vector of residuals
-    res = Vector{OpticalResidual{T, U}}(undef, length(optical))
-    for i in eachindex(optical)
-        ra, dec = zero(U), zero(U)
-        wra, wdec = w8s[i]
-        dra, ddec = bias[i]
-        corr = corrs[i]
-        outlier = -1 < corr < 1 ? outliers[i] : true
-        res[i] = OpticalResidual{T, U}(ra, dec, wra, wdec, dra, ddec, corr, outlier)
+    @assert nobs(wsm) == nobs(dsm) "Weighting and debiasing schemes must have the \
+        same number of observations"
+    w8s = weights(wsm, idxs)
+    bias = debias(dsm, idxs)
+    korrs = corrs(wsm, idxs)
+    outliers = outliers(wsm, idxs)
+    res = Vector{OpticalResidual{T, U}}(undef, length(idxs))
+    for i in eachindex(res)
+        res[i] = OpticalResidual{T, U}(zero(U), zero(U), w8s[i]..., bias[i]...,
+                                       korrs[i], outliers[i])
     end
-
     return res
 end
 
 """
-    residuals(optical, w8s, bias [, corrs [, outliers]]; kwargs...) where {T <: Real}
+    residuals(optical, wsm, dsm; kwargs...) where {T <: Real}
 
 Compute the observed minus computed residuals for a vector of optical astrometry.
 Corrections due to Earth orientation, LOD and polar motion are computed by default.
@@ -234,12 +236,8 @@ See also [`OpticalResidual`](@ref) and [`compute_radec`](@ref).
 # Arguments
 
 - `optical::AbstractOpticalVector{T}`: optical astrometry.
-- `w8s::AbstractVector{NTuple{2, T}}`: statistical weights.
-- `bias::AbstractVector{NTuple{2, T}}`: debiasing corrections.
-- `corrs::AbstractVector{T}`: correlations (default:
-    `zeros(T, length(optical))`).
-- `outliers::AbstractVector{Bool}`: outlier flags (default:
-    `falses(length(optical))`).
+- `wsm::AbstractWeightingScheme{T}`: weighting scheme.
+- `dsm::AbstractDebiasingScheme{T}`: debiasing scheme.
 
 # Keyword arguments
 
@@ -248,15 +246,15 @@ See also [`OpticalResidual`](@ref) and [`compute_radec`](@ref).
 - `xvs`: Sun ephemeris (default: `sunposvel`).
 - `xva`: asteroid ephemeris.
 
-All ephemeris must take [et seconds since J2000] and return [barycentric position in km
-and velocity in km/sec].
+All ephemeris must take [et seconds since J2000] and return [barycentric position in
+km and velocity in km/sec].
 """
-function residuals(optical::AbstractOpticalVector{T},
-                   w8s::AbstractVector{NTuple{2, T}},
-                   bias::AbstractVector{NTuple{2, T}},
-                   corrs::AbstractVector{T} = zeros(T, length(optical)),
-                   outliers::AbstractVector{Bool} = falses(length(optical));
-                   xva::AstEph, kwargs...) where {AstEph, T <: Real}
+function residuals(
+        optical::AbstractOpticalVector{T},
+        wsm::AbstractWeightingScheme{T},
+        dsm::AbstractDebiasingScheme{T};
+        xva::AstEph, kwargs...
+    ) where {AstEph, T <: Real}
     # UTC time of first optical observation
     utc1 = date(optical[1])
     # TDB seconds since J2000.0 for first optical observation
@@ -268,7 +266,7 @@ function residuals(optical::AbstractOpticalVector{T},
     # Buffer
     buffer = [OpticalBuffer(a1_et1) for _ in eachindex(optical)]
     # Vector of residuals
-    res = init_optical_residuals(U, optical, w8s, bias, corrs, outliers)
+    res = init_optical_residuals(U, wsm, dsm)
     residuals!(res, optical, buffer; xva, kwargs...)
 
     return res

--- a/src/astrometry/opticalrwo.jl
+++ b/src/astrometry/opticalrwo.jl
@@ -178,6 +178,7 @@ corr(::OpticalRWO{T}) where {T <: Real} = zero(T)
 trackletid(x::OpticalRWO) = ""
 
 isdeprecated(x::OpticalRWO) = x.T == 'X'
+isoutlier(x::OpticalRWO) = iszero(x.sel_A)
 
 designation(x::OpticalRWO) = x.design
 

--- a/src/astrometry/weightingscheme.jl
+++ b/src/astrometry/weightingscheme.jl
@@ -52,7 +52,7 @@ end
 # Override getid, weights, corrs and outliers
 getid(::UniformWeights) = "Uniform"
 weights(x::UniformWeights) = x.weights
-corrs(x::UniformWeights) = x.corr
+corrs(x::UniformWeights) = x.corrs
 outliers(x::UniformWeights) = x.outliers
 
 # Override update!
@@ -86,7 +86,7 @@ end
 # Override getid, weights, corrs and outliers
 getid(::SourceWeights) = "Source"
 weights(x::SourceWeights) = x.weights
-corrs(x::SourceWeights) = x.corr
+corrs(x::SourceWeights) = x.corrs
 outliers(x::SourceWeights) = x.outliers
 
 # Override update!
@@ -124,7 +124,7 @@ end
 # Override getid, weights, corrs and outliers
 getid(::Veres17) = "Veres et al. (2017)"
 weights(x::Veres17) = x.weights
-corrs(x::Veres17) = x.corr
+corrs(x::Veres17) = x.corrs
 outliers(x::Veres17) = x.outliers
 
 # Override update!

--- a/src/astrometry/weightingscheme.jl
+++ b/src/astrometry/weightingscheme.jl
@@ -6,16 +6,29 @@ Supertype for the optical astrometry weighting schemes interface.
 Every weighting scheme `W{T}` must:
 - be a mutable subtype of `AbstractWeightingScheme{T}`,
 - implement a `W(::AbstractOpticalVector{T})` constructor,
-- override `weights(::W)`,
-- override `corr(::W)`,
-- override `getid(::W)`,
+- override `getid(::W)`, `weights(::W)`, `corrs(::W)` and `outliers(::W)`.
 - override `update!(::W{T}, ::AbstractOpticalVector{T})`.
 """
 abstract type AbstractWeightingScheme{T} <: AbstractAstrometryErrorModel{T} end
 
+# AbstractWeightingScheme interface
+nobs(x::AbstractWeightingScheme) = length(weights(x))
+
+weights(x::AbstractWeightingScheme, i::Int) = weights(x)[i]
+corrs(x::AbstractWeightingScheme, i::Int) = corrs(x)[i]
+outliers(x::AbstractWeightingScheme, i::Int) = outliers(x)[i]
+
+weights(x::AbstractWeightingScheme, i::AbstractVector{Int}) = view(weights(x), i)
+corrs(x::AbstractWeightingScheme, i::AbstractVector{Int}) = view(corrs(x), i)
+outliers(x::AbstractWeightingScheme, i::AbstractVector{Int}) = view(outliers(x), i)
+
+setoutlier!(x::AbstractWeightingScheme, i::Int, y::Bool) = outliers(x)[i] = y
+setoutlier!(x::AbstractWeightingScheme, i::AbstractVector{Int}, y::AbstractVector{Bool}) =
+    outliers(x, i) .= y
+
 # Print method for AbstractWeightingScheme
 show(io::IO, x::AbstractWeightingScheme) = print(io, getid(x),
-    " weighting scheme with ", length(weights(x)), " observations")
+    " weighting scheme with ", nobs(x), " observations")
 
 """
     UniformWeights{T} <: AbstractWeightingScheme{T}
@@ -24,29 +37,29 @@ Uniform optical astrometry weighting scheme.
 """
 mutable struct UniformWeights{T} <: AbstractWeightingScheme{T}
     weights::Vector{NTuple{2, T}}
-    corr::Vector{T}
+    corrs::Vector{T}
+    outliers::BitVector
 end
 
 # Constructor
 function UniformWeights(optical::AbstractOpticalVector{T}) where {T <: Real}
     weights = [(one(T), one(T)) for _ in eachindex(optical)]
-    corr = [zero(T) for _ in eachindex(optical)]
-    return UniformWeights{T}(weights, corr)
+    corrs = [zero(T) for _ in eachindex(optical)]
+    outliers = isdeprecated.(optical)
+    return UniformWeights{T}(weights, corrs, outliers)
 end
 
-# Override weights
-weights(x::UniformWeights) = x.weights
-
-# Override corr
-corr(x::UniformWeights) = x.corr
-
-# Override getid
+# Override getid, weights, corrs and outliers
 getid(::UniformWeights) = "Uniform"
+weights(x::UniformWeights) = x.weights
+corrs(x::UniformWeights) = x.corr
+outliers(x::UniformWeights) = x.outliers
 
 # Override update!
 function update!(x::UniformWeights{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
     x.weights = [(one(T), one(T)) for _ in eachindex(optical)]
-    x.corr = [zero(T) for _ in eachindex(optical)]
+    x.corrs = [zero(T) for _ in eachindex(optical)]
+    x.outliers = isdeprecated.(optical)
     return nothing
 end
 
@@ -57,7 +70,8 @@ Source optical astrometry weighting scheme.
 """
 mutable struct SourceWeights{T} <: AbstractWeightingScheme{T}
     weights::Vector{NTuple{2, T}}
-    corr::Vector{T}
+    corrs::Vector{T}
+    outliers::BitVector
 end
 
 # Constructors
@@ -65,23 +79,22 @@ function SourceWeights(optical::AbstractOpticalVector{T}) where {T <: Real}
     σs = rms.(optical)
     weights = @. tuple(1 / first(σs), 1 / last(σs))
     corrs = corr.(optical)
-    return SourceWeights{T}(weights, corrs)
+    outliers = isoutlier.(optical)
+    return SourceWeights{T}(weights, corrs, outliers)
 end
 
-# Override weights
-weights(x::SourceWeights) = x.weights
-
-# Override corr
-corr(x::SourceWeights) = x.corr
-
-# Override getid
+# Override getid, weights, corrs and outliers
 getid(::SourceWeights) = "Source"
+weights(x::SourceWeights) = x.weights
+corrs(x::SourceWeights) = x.corr
+outliers(x::SourceWeights) = x.outliers
 
 # Override update!
 function update!(x::SourceWeights{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
     σs = rms.(optical)
     x.weights = @. tuple(1 / first(σs), 1 / last(σs))
-    x.corr = corr.(optical)
+    x.corrs = corr.(optical)
+    x.outliers = isoutlier.(optical)
     return nothing
 end
 
@@ -96,29 +109,29 @@ Veres et al. (2017) optical astrometry weighting scheme.
 """
 mutable struct Veres17{T} <: AbstractWeightingScheme{T}
     weights::Vector{NTuple{2, T}}
-    corr::Vector{T}
+    corrs::Vector{T}
+    outliers::BitVector
 end
 
 # Constructor
 function Veres17(optical::AbstractOpticalVector{T}) where {T <: Real}
     weights = w8sveres17(optical)
-    corr = [zero(T) for _ in eachindex(optical)]
-    return Veres17{T}(weights, corr)
+    corrs = [zero(T) for _ in eachindex(optical)]
+    outliers = isdeprecated.(optical)
+    return Veres17{T}(weights, corrs, outliers)
 end
 
-# Override weights
-weights(x::Veres17) = x.weights
-
-# Override corr
-corr(x::Veres17) = x.corr
-
-# Override getid
+# Override getid, weights, corrs and outliers
 getid(::Veres17) = "Veres et al. (2017)"
+weights(x::Veres17) = x.weights
+corrs(x::Veres17) = x.corr
+outliers(x::Veres17) = x.outliers
 
 # Override update!
 function update!(x::Veres17{T}, optical::AbstractOpticalVector{T}) where {T <: Real}
     x.weights = w8sveres17(optical)
-    x.corr = [zero(T) for _ in eachindex(optical)]
+    x.corrs = [zero(T) for _ in eachindex(optical)]
+    x.outliers = isdeprecated.(optical)
     return nothing
 end
 

--- a/src/impactmonitoring/improblem.jl
+++ b/src/impactmonitoring/improblem.jl
@@ -48,12 +48,13 @@ function minmaxdates(x::IMProblem)
     return t0, tf
 end
 
+# Initialize vector of optical residuals
 function init_optical_residuals(
-        ::Type{U}, x::AbstractIMProblem{D, T}
+        ::Type{U}, IM::AbstractIMProblem{D, T}
     ) where {D, T <: Real, U <: Number}
-    # Initialize vector of optical residuals
-    res = Vector{OpticalResidual{T, U}}(undef, length(x.orbit.ores))
-    for (i, r) in enumerate(x.orbit.ores)
+    @unpack orbit = IM
+    res = Vector{OpticalResidual{T, U}}(undef, length(orbit.ores))
+    for (i, r) in enumerate(orbit.ores)
         res[i] = OpticalResidual{T, U}(zero(U), zero(U), wra(r), wdec(r), dra(r), ddec(r),
                                        corr(r), isoutlier(r))
     end

--- a/src/orbitdetermination/abstractorbit/abstractorbit.jl
+++ b/src/orbitdetermination/abstractorbit/abstractorbit.jl
@@ -153,12 +153,10 @@ function init_optical_residuals(::Type{V}, orbit::AbstractOrbit{D, T, U}) where 
                                 T <: Real, U <: Number, V <: Number}
     # Initialize vector of optical residuals
     res = Vector{OpticalResidual{T, V}}(undef, noptical(orbit))
-    for i in eachindex(res)
-        ra, dec = zero(V), zero(V)
-        @unpack wra, wdec, dra, ddec, corr, outlier = orbit.ores[i]
-        res[i] = OpticalResidual{T, V}(ra, dec, wra, wdec, dra, ddec, corr, outlier)
+    for (i, r) in enumerate(orbit.ores)
+        res[i] = OpticalResidual{T, V}(zero(V), zero(V), wra(r), wdec(r), dra(r),
+                                       ddec(r), corr(r), isoutlier(r))
     end
-
     return res
 end
 

--- a/src/orbitdetermination/abstractorbit/leastsquaresorbit.jl
+++ b/src/orbitdetermination/abstractorbit/leastsquaresorbit.jl
@@ -28,22 +28,16 @@ function init_optical_residuals(::Type{U}, od::ODProblem,
     T = scalartype(od)
     # Optical astrometry
     optical1, optical2 = optical(od), optical(orbit)
-    # Weights and debiasing factors
-    w8s, bias = weights(od), debias(od)
-    # Correlations
-    corrs = corr(od)
+    # Weights, debiasing factors, correlations and outliers
+    w8s, bias, korrs, outs = weights(od), debias(od), corrs(od), outliers(od)
     # Initialize vector of optical residuals
     res = Vector{OpticalResidual{T, U}}(undef, length(optical1))
     for i in eachindex(optical1)
-        ra, dec = zero(U), zero(U)
-        wra, wdec, = w8s[i]
-        dra, ddec = bias[i]
-        corr = corrs[i]
         j = findfirst(==(optical1[i]), optical2)
-        outlier = isnothing(j) ? false : isoutlier(orbit.ores[j])
-        res[i] = OpticalResidual{T, U}(ra, dec, wra, wdec, dra, ddec, corr, outlier)
+        outlier = isnothing(j) ? outs[i] : isoutlier(orbit.ores[j])
+        res[i] = OpticalResidual{T, U}(zero(U), zero(U), w8s[i]..., bias[i]...,
+                                       korrs[i], outlier)
     end
-
     return res
 end
 

--- a/src/orbitdetermination/jtls.jl
+++ b/src/orbitdetermination/jtls.jl
@@ -274,8 +274,9 @@ function jtls(
         all(>(0), diag(fit.Γ)) || break
         # Outlier rejection
         if outrej
+            mro = view(outliers(od), oidxs)
             outlier_rejection!(view(res, oidxs), fit.x, fit.Γ, orcache;
-                χ2_rec, χ2_rej, fudge, max_per)
+                mro, χ2_rec, χ2_rej, fudge, max_per)
         end
         # Update orbit
         orbits[i] = updateorbit(LeastSquaresOrbit(
@@ -373,8 +374,9 @@ function jtls(
         all(>(0), diag(fit.Γ)) || break
         # Outlier rejection
         if outrej
+            mro = view(outliers(od), oidxs)
             outlier_rejection!(view(res[1], oidxs), fit.x, fit.Γ, orcache;
-                χ2_rec, χ2_rej, fudge, max_per)
+                mro, χ2_rec, χ2_rej, fudge, max_per)
         end
         # Update orbit
         orbits[i] = updateorbit(LeastSquaresOrbit(

--- a/src/orbitdetermination/leastsquares/outlierrejection.jl
+++ b/src/orbitdetermination/leastsquares/outlierrejection.jl
@@ -24,14 +24,17 @@ end
 """
     outlier_rejection!(res, x, Γ [, cache]; kwargs...)
 
-Reject outliers in a vector of optical residuals `res` using the Carpino et al. (2003)
-algorithm. The residuals are evaluated at `x` and have a covariance matrix `Γ`. A
-pre-allocated `cache` can be passed to save memory.
+Reject outliers in a vector of optical residuals `res` using the
+Carpino et al. (2003) algorithm. The residuals are evaluated at `x`
+and have a covariance matrix `Γ`. A pre-allocated `cache` can be
+passed to save memory.
 
 See also [`carpino_smoothing`](@ref).
 
 # Keyword arguments
 
+- `mro::AbstractVector{Bool}`: manually rejected observations
+    (default: `falses(length(res))`).
 - `χ2_rec::Real`: recovery threshold (default: `7.0`).
 - `χ2_rej::Real`: rejection threshold (default: `8.0`).
 - `fudge::Real`: rejection fudge term coefficient (default: `400.0`).
@@ -42,10 +45,14 @@ See also [`carpino_smoothing`](@ref).
     See:
     - https://doi.org/10.1016/S0019-1035(03)00051-4
 """
-function outlier_rejection!(res::AbstractVector{OpticalResidual{T, TaylorN{T}}},
-    x::Vector{T}, Γ::Matrix{T}, cache::OutlierRejectionCache{T} =
-    OutlierRejectionCache(T, length(res)); χ2_rec::T = 7.0, χ2_rej::T = 8.0,
-    fudge::T = 400.0, α::T = 0.25, max_per::T = 10.0) where {T <: Real}
+function outlier_rejection!(
+        res::AbstractVector{OpticalResidual{T, TaylorN{T}}},
+        x::Vector{T}, Γ::Matrix{T},
+        cache::OutlierRejectionCache{T} = OutlierRejectionCache(T, length(res));
+        mro::AbstractVector{Bool} = falses(length(res)),
+        χ2_rec::T = 7.0, χ2_rej::T = 8.0,
+        fudge::T = 400.0, α::T = 0.25, max_per::T = 10.0
+    ) where {T <: Real}
     # Number of residuals
     L = length(res)
     # Unfold
@@ -99,15 +106,16 @@ function outlier_rejection!(res::AbstractVector{OpticalResidual{T, TaylorN{T}}},
     χ2_rej = max(χ2_rej + carpino_smoothing(N_sel, fudge), α * χ2_max)
     # Rejection / recovery loop
     @inbounds for i in idxs
+        # Manually rejected observation
+        if mro[i]
+            res[i] = setoutlier(res[i], true)
         # Reject
-        if χ2s[i] > χ2_rej && N_drop < max_drop && !mask[i]
-            res[i] = OpticalResidual{T, TaylorN{T}}(ra(res[i]), dec(res[i]), wra(res[i]),
-                wdec(res[i]), dra(res[i]), ddec(res[i]), corr(res[i]), true)
+        elseif χ2s[i] > χ2_rej && N_drop < max_drop && !mask[i]
+            res[i] = setoutlier(res[i], true)
             N_drop += 1
         # Recover
         elseif χ2s[i] < χ2_rec && mask[i]
-            res[i] = OpticalResidual{T, TaylorN{T}}(ra(res[i]), dec(res[i]), wra(res[i]),
-                wdec(res[i]), dra(res[i]), ddec(res[i]), corr(res[i]), false)
+            res[i] = setoutlier(res[i], false)
             N_drop -= 1
         end
     end

--- a/src/orbitdetermination/odproblem.jl
+++ b/src/orbitdetermination/odproblem.jl
@@ -95,12 +95,10 @@ nobs(x::ODProblem) = noptical(x) + nradar(x)
 opticalindices(x::ODProblem) = eachindex(x.optical)
 radarindices(x::MixedODProblem) = eachindex(x.radar)
 
-opticaloutliers(x::ODProblem) = falses(noptical(x))
-radaroutliers(x::MixedODProblem) = falses(nradar(x))
-
 weights(x::ODProblem) = weights(x.weights)
 debias(x::ODProblem) = debias(x.debias)
-corr(x::ODProblem) = corr(x.weights)
+corrs(x::ODProblem) = corrs(x.weights)
+outliers(x::ODProblem) = outliers(x.weights)
 
 function minmaxdates(x::ODProblem)
     t0, tf = minmaxdates(x.optical)
@@ -121,17 +119,18 @@ function update!(x::AbstractODProblem{D, T},
     return nothing
 end
 
-function init_optical_residuals(::Type{U}, od::ODProblem, idxs = opticalindices(od),
-                                outliers = opticaloutliers(od)) where {U <: Number}
-    optical = view(od.optical, idxs)
-    w8s = view(weights(od), idxs)
-    bias = view(debias(od), idxs)
-    corrs = view(corr(od), idxs)
-    return init_optical_residuals(U, optical, w8s, bias, corrs, outliers)
+function init_optical_residuals(
+        ::Type{U}, od::ODProblem,
+        idxs::AbstractVector{Int} = opticalindices(od),
+    ) where {U <: Number}
+    return init_optical_residuals(U, od.weights, od.debias, idxs)
 end
 
-function init_radar_residuals(::Type{U}, od::MixedODProblem, idxs = radarindices(od),
-                              outliers = radaroutliers(od)) where {U <: Number}
+function init_radar_residuals(
+        ::Type{U}, od::MixedODProblem,
+        idxs::AbstractVector{Int} = radarindices(od),
+        outliers = falses(nradar(x))
+    ) where {U <: Number}
     radar = view(od.radar, idxs)
     return init_radar_residuals(U, radar, outliers)
 end

--- a/src/orbitdetermination/odproblem.jl
+++ b/src/orbitdetermination/odproblem.jl
@@ -129,7 +129,7 @@ end
 function init_radar_residuals(
         ::Type{U}, od::MixedODProblem,
         idxs::AbstractVector{Int} = radarindices(od),
-        outliers = falses(nradar(x))
+        outliers = falses(nradar(od))
     ) where {U <: Number}
     radar = view(od.radar, idxs)
     return init_radar_residuals(U, radar, outliers)

--- a/test/optical.jl
+++ b/test/optical.jl
@@ -175,7 +175,7 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         @test objects2 == objects3
 
     end
-
+    #=
     @testset "OpticalRWO" begin
 
         using NEOs: NEODyS2_OPTICAL_HEADER, OpticalRWO, parse_optical_rwo, isoccultation
@@ -306,6 +306,7 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         @test all(@. isoccultation(optical5.observatory))
 
     end
+    =#
 
     @testset "OpticalADES" begin
 
@@ -739,10 +740,10 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         @test all(==((1.0, 1.0)), weights(w11))
         @test all(==((1.0, 1.0)), weights(w12))
 
-        @test length(corr(w11)) == length(corr(w12)) == length(corr(w13))
-        @test all(iszero, corr(w11))
-        @test all(iszero, corr(w12))
-        @test all(iszero, corr(w13))
+        @test length(corrs(w11)) == length(corrs(w12)) == length(corrs(w13))
+        @test all(iszero, corrs(w11))
+        @test all(iszero, corrs(w12))
+        @test all(iszero, corrs(w13))
 
         w21 = UniformWeights(optical2)
         w22 = SourceWeights(optical2)
@@ -763,10 +764,10 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
         all( @. $weights(w22) == tuple(1 / getfield(optical2, :ra_rms),
             1 / getfield(optical2, :dec_rms)) )
 
-        @test length(corr(w21)) == length(corr(w22)) == length(corr(w23))
-        @test all(iszero, corr(w21))
-        @test all(iszero, corr(w22))
-        @test all(iszero, corr(w23))
+        @test length(corrs(w21)) == length(corrs(w22)) == length(corrs(w23))
+        @test all(iszero, corrs(w21))
+        @test all(iszero, corrs(w22))
+        @test all(iszero, corrs(w23))
 
         w31 = UniformWeights(optical3)
         w32 = SourceWeights(optical3)
@@ -784,39 +785,39 @@ const TEST_DATA = joinpath(pkgdir(NEOs), "test", "data")
             w == (1 / σx[1], 1 / σx[2])
         end)
 
-        @test length(corr(w31)) == length(corr(w32)) == length(corr(w33))
-        @test all(iszero, corr(w31))
-        @test all(map(corr(w32), optical3) do ρ, x
+        @test length(corrs(w31)) == length(corrs(w32)) == length(corrs(w33))
+        @test all(iszero, corrs(w31))
+        @test all(map(corrs(w32), optical3) do ρ, x
             ρ == (isnan(x.rmscorr) ? 0.0 : x.rmscorr)
         end)
-        @test all(iszero, corr(w33))
+        @test all(iszero, corrs(w33))
 
         @test weights(w13) == weights(w23) == weights(w33)
-        @test corr(w13) == corr(w23) == corr(w33)
+        @test corrs(w13) == corrs(w23) == corrs(w33)
 
         update!(w11, optical1[1:1])
         update!(w12, optical1[1:1])
         update!(w13, optical1[1:1])
 
-        @test w11.weights == [(1.0, 1.0)] && w11.corr == [0.0]
-        @test w12.weights == [(1.0, 1.0)] && w12.corr == [0.0]
-        @test w13.weights == [(1.0, 1.0)] && w13.corr == [0.0]
+        @test w11.weights == [(1.0, 1.0)] && w11.corrs == [0.0]
+        @test w12.weights == [(1.0, 1.0)] && w12.corrs == [0.0]
+        @test w13.weights == [(1.0, 1.0)] && w13.corrs == [0.0]
 
         update!(w21, optical2[1:1])
         update!(w22, optical2[1:1])
         update!(w23, optical2[1:1])
 
-        @test w21.weights == [(1.0, 1.0)] && w21.corr == [0.0]
-        @test w22.weights == [(1.0, 1.0)] && w22.corr == [0.0]
-        @test w23.weights == [(1.0, 1.0)] && w23.corr == [0.0]
+        @test w21.weights == [(1.0, 1.0)] && w21.corrs == [0.0]
+        @test w22.weights == [(1.0, 1.0)] && w22.corrs == [0.0]
+        @test w23.weights == [(1.0, 1.0)] && w23.corrs == [0.0]
 
         update!(w31, optical3[1:1])
         update!(w32, optical3[1:1])
         update!(w33, optical3[1:1])
 
-        @test w31.weights == [(1.0, 1.0)] && w31.corr == [0.0]
-        @test w32.weights == [(1.0, 1.0)] && w32.corr == [0.0]
-        @test w33.weights == [(1.0, 1.0)] && w33.corr == [0.0]
+        @test w31.weights == [(1.0, 1.0)] && w31.corrs == [0.0]
+        @test w32.weights == [(1.0, 1.0)] && w32.corrs == [0.0]
+        @test w33.weights == [(1.0, 1.0)] && w33.corrs == [0.0]
 
     end
 

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -151,8 +151,8 @@ end
         # Read optical astrometry file
         optical_2023DW = read_optical_mpc80(joinpath(TEST_DATA, "2023DW.txt"))
         # Make weigths and debiasing corrections
-        w8s = weights(Veres17(optical_2023DW))
-        bias = debias(Eggl20(optical_2023DW))
+        w8s = Veres17(optical_2023DW)
+        bias = Eggl20(optical_2023DW)
 
         # Compute normalized residuals
         _res_ = NEOs.residuals(
@@ -166,8 +166,8 @@ end
         @test iszero(zero(eltype(_res_)))
         @test all(@. isa(string(_res_), String))
         @test all(@. residual(_res_) == tuple(ra(_res_), dec(_res_)))
-        @test all(@. weight(_res_) == w8s)
-        @test all(@. debias(_res_) == bias)
+        @test all(@. weight(_res_) == $weights(w8s))
+        @test all(@. debias(_res_) == $debias(bias))
         @test sqrt(chi2(_res_)) ≤ sum(chi, _res_)
         @test all(@. logchi(_res_) < log10chi(_res_) || chi(_res_) > 1)
 
@@ -206,8 +206,8 @@ end
         @test iszero(zero(eltype(_res1_)))
         @test all(@. isa(string(_res1_), String))
         @test all(@. residual(_res1_) == tuple(ra(_res1_), dec(_res1_)))
-        @test all(@. weight(_res1_) == w8s)
-        @test all(@. debias(_res1_) == bias)
+        @test all(@. weight(_res1_) == $weights(w8s))
+        @test all(@. debias(_res1_) == $debias(bias))
         @test sqrt(chi2(_res1_)) ≤ sum(chi, _res1_)
         @test all(@. logchi(_res1_) < log10chi(_res1_) || chi(_res1_) > 1)
 
@@ -262,8 +262,8 @@ end
         # Read optical astrometry file
         optical_Apophis = read_optical_mpc80(joinpath(TEST_DATA, "99942_Tholen_etal_2013.dat"))
         # Make weights and debiasing corrections
-        w8s = weights(Veres17(optical_Apophis))
-        bias = debias(Eggl20(optical_Apophis))
+        w8s = Veres17(optical_Apophis)
+        bias = Eggl20(optical_Apophis)
 
         # Compute optical astrometry residuals
         res_optical = NEOs.residuals(
@@ -277,8 +277,8 @@ end
         @test iszero(zero(eltype(res_optical)))
         @test all(@. isa(string(res_optical), String))
         @test all(@. residual(res_optical) == tuple(ra(res_optical), dec(res_optical)))
-        @test all(@. weight(res_optical) == w8s)
-        @test all(@. debias(res_optical) == bias)
+        @test all(@. weight(res_optical) == $weights(w8s))
+        @test all(@. debias(res_optical) == $debias(bias))
         @test sqrt(chi2(res_optical)) ≤ sum(chi, res_optical)
         @test all(@. logchi(res_optical) < log10chi(res_optical) || chi(res_optical) > 1)
 
@@ -461,8 +461,8 @@ end
         # Read optical astrometry file
         optical_Apophis = read_optical_mpc80(joinpath(TEST_DATA, "99942_Tholen_etal_2013.dat"))
         # Make weights and debiasing corrections
-        w8s = weights(Veres17(optical_Apophis))
-        bias = debias(Eggl20(optical_Apophis))
+        w8s = Veres17(optical_Apophis)
+        bias = Eggl20(optical_Apophis)
 
         # Compute optical astrometry residuals
         res_optical = NEOs.residuals(optical_Apophis, w8s, bias;
@@ -474,8 +474,8 @@ end
         @test iszero(zero(eltype(res_optical)))
         @test all(@. isa(string(res_optical), String))
         @test all(@. residual(res_optical) == tuple(ra(res_optical), dec(res_optical)))
-        @test all(@. weight(res_optical) == w8s)
-        @test all(@. debias(res_optical) == bias)
+        @test all(@. weight(res_optical) == $weights(w8s))
+        @test all(@. debias(res_optical) == $debias(bias))
         @test sqrt(chi2(res_optical)) ≤ sum(chi, res_optical)
         # @test all(@. logchi(res_optical) < log10chi(res_optical) || chi(res_optical) > 1)
 


### PR DESCRIPTION
This PR tackles https://github.com/PerezHz/NEOs.jl/issues/185 by generalizing the weighting schemes interface to include a BitVector that can be used to manually reject optical observations.