### PR TITLE
Optimize astrometry parsing

### DIFF
--- a/src/NEOs.jl
+++ b/src/NEOs.jl
@@ -19,8 +19,7 @@ using AngleBetweenVectors, AutoHashEquals, Dates, Downloads, HTTP, InteractiveUt
 
 using AstroAngles: hms2rad, rad2hms, dms2rad, rad2dms
 using AstroMOID: wisric_moid
-using DataFrames: AbstractDataFrame, AsTable, DataFrame, DataFrameRow, nrow, eachrow,
-      eachcol, groupby, combine
+using DataFrames: AsTable, DataFrame, nrow, groupby, combine
 using Dates: epochms2datetime
 using DelimitedFiles: readdlm
 using Distributions: Chisq, Normal, Uniform, cdf, quantile

--- a/src/astrometry/computeradec.jl
+++ b/src/astrometry/computeradec.jl
@@ -58,7 +58,7 @@ function compute_radec(
     rv_a_t_r = xva(et_r_secs)
     r_a_t_r = rv_a_t_r[1:3]
     # Compute geocentric position/velocity of receiving antenna in inertial frame [km, km/s]
-    RV_r = obsposvelECI(observatory, et_r_secs)
+    RV_r = obsposvelECI(observatory, datetime2julian(t_r_utc))
     R_r = RV_r[1:3]
     # Receiver barycentric position and velocity at receive time
     r_r_t_r = r_e_t_r + R_r
@@ -198,7 +198,7 @@ function compute_radec(
     evaleph!(rv_a_t_r, et_r_secs, xva[1], xva[2])
     r_a_t_r = rv_a_t_r[1:3]
     # Compute geocentric position/velocity of receiving antenna in inertial frame [km, km/s]
-    RV_r = obsposvelECI(observatory, et_r_secs)
+    RV_r = obsposvelECI(observatory, datetime2julian(t_r_utc))
     R_r = RV_r[1:3]
     # Receiver barycentric position and velocity at receive time
     r_r_t_r = r_e_t_r + R_r
@@ -337,7 +337,7 @@ function compute_radec(
     evaleph!(rv_a_t_r, et_r_secs, xva[1], xva[2])
     r_a_t_r = rv_a_t_r[1:3]
     order = TaylorSeries.order(r_a_t_r[1])
-    RV_r = obsposvelECI(observatory, et_r_secs)
+    RV_r = obsposvelECI(observatory, datetime2julian(t_r_utc))
     R_r = RV_r[1:3]
     r_r_t_r = r_e_t_r + R_r
     E_H_vec = e_D_vec  = r_r_t_r - r_s_t_r

--- a/src/astrometry/neocpobject.jl
+++ b/src/astrometry/neocpobject.jl
@@ -77,39 +77,39 @@ function neocpparse(name, ::Type{T}, x) where {T <: Real}
     return y
 end
 
-NEOCPObject(r::DataFrameRow) = NEOCPObject{Float64}(
-    r.desig, r.score, r.date, r.ra, r.dec, r.V, r.updated,
-    r.nobs, r.arc, r.H, r.notseen, r.source
-)
-
-function parse_neocp_objects(text::AbstractString)
-    # Parse lines
-    lines = split(text, '\n', keepempty = false)
-    # Note: Some objects that were moved to the PCCP have a very long arc length,
-    # hence having a registry with more than 101 columns (see e.g. P22aZna)
-    filter!(x -> length(x) == 101, lines)
-    L = length(lines)
-    # Construct DataFrame
-    R = NEOCPObject{Float64}
-    names, types = fieldnames(R), fieldtypes(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(lines)
-        for (name, type, idxs) in zip(names, types, NEOCP_OBJECT_COLUMNS)
-            x = strip(view(line, idxs))
-            df[i, name] = neocpparse(name, type, x)
+@eval begin
+    function parse_neocp_objects(text::AbstractString)
+        # Parse lines
+        lines = split(text, '\n', keepempty = false)
+        # Note: Some objects that were moved to the PCCP have a very long arc length,
+        # hence having a registry with more than 101 columns (see e.g. P22aZna)
+        filter!(x -> length(x) == 101, lines)
+        isempty(lines) && return NEOCPObject{Float64}[]
+        # Main parse loop
+        objects = Vector{NEOCPObject{Float64}}(undef, length(lines))
+        for (i, line) in enumerate(lines)
+            $([:(
+                $(name) = neocpparse(
+                    $(QuoteNode(name)),
+                    $(fieldtype(NEOCPObject{Float64}, name)),
+                    strip(view(line, $idxs))
+                )
+            ) for (name, idxs) in zip(fieldnames(NEOCPObject{Float64}), NEOCP_OBJECT_COLUMNS)
+            if name != :source]...)
+            # Source string
+            source = string(line)
+            # Assemble object
+            objects[i] = NEOCPObject{Float64}($(
+                [name for name in fieldnames(NEOCPObject{Float64})]...
+            ))
         end
-    end
-    # Source string
-    df.source = lines
-    # Parse objects
-    objects = NEOCPObject.(eachrow(df))
-    # Eliminate repeated entries
-    unique!(objects)
-    # Sort by date
-    sort!(objects)
+        # Eliminate repeated entries
+        unique!(objects)
+        # Sort by date
+        sort!(objects)
 
-    return objects
+        return objects
+    end
 end
 
 """

--- a/src/astrometry/opticalades.jl
+++ b/src/astrometry/opticalades.jl
@@ -190,36 +190,26 @@ function adesparse(name, ::Type{T}, x) where {T <: Real}
     end
 end
 
-OpticalADES(r::DataFrameRow) = OpticalADES{Float64}(
-    r.permid, r.provid, r.trksub, r.obsid, r.trkid, r.mode, r.stn, r.sys, r.ctr,
-    r.pos1, r.pos2, r.pos3, r.vel1, r.vel2, r.vel3, r.poscov11, r.poscov12,
-    r.poscov13, r.poscov22, r.poscov23, r.poscov33, r.prog, r.obstime,
-    r.rmstime, r.ra, r.dec, r.rastar, r.decstar, r.deltara, r.deltadec,
-    r.rmsra, r.rmsdec, r.rmscorr, r.astcat, r.mag, r.rmsmag, r.band,
-    r.photcat, r.ref, r.disc, r.subfmt, r.prectime, r.precra, r.precdec,
-    r.unctime, r.notes, r.remarks, r.deprecated, r.source, r.timeofday
-)
-
-function parse_optical_ades(text::String; eop::EOPIAU = EOP_IAU2000A)
-    # Parse XML
-    node = parse(LazyNode, text)
-    # Locate the root <ades> element and its observation elements by node type:
-    # XML.jl >= 0.4 preserves inter-element whitespace as Text nodes, so positional
-    # indexing (node[2]) and unfiltered children iteration would hit Text nodes.
-    root = only(filter(n -> XML.nodetype(n) == XML.Element, children(node)))
-    obs = filter(n -> XML.nodetype(n) == XML.Element, children(root))
-    L = length(obs)
-    # Construct DataFrame
-    R = OpticalADES{Float64}
-    names = fieldnames(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(obs)
-        for child in children(line)
-            XML.nodetype(child) == XML.Element || continue
-            name = Symbol(lowercase(tag(child)))
-            if name in names
-                type = fieldtype(R, name)
+@eval begin
+    function parse_optical_ades(text::String; eop::EOPIAU = EOP_IAU2000A)
+        # Parse XML
+        node = parse(LazyNode, text)
+        # Locate the root <ades> element and its observation elements by node type:
+        # XML.jl >= 0.4 preserves inter-element whitespace as Text nodes, so positional
+        # indexing (node[2]) and unfiltered children iteration would hit Text nodes.
+        root = only(filter(n -> XML.nodetype(n) == XML.Element, children(node)))
+        obs = filter(n -> XML.nodetype(n) == XML.Element, children(root))
+        isempty(obs) && return OpticalADES{Float64}[]
+        # Main parse loop
+        optical = Vector{OpticalADES{Float64}}(undef, length(obs))
+        for (i, line) in enumerate(obs)
+            $([:(
+                $(name) = astrometrydefault($(fieldtype(OpticalADES{Float64}, name)))
+            ) for name in fieldnames(OpticalADES{Float64}) if name ∉ (:timeofday, :source)
+            ]...)
+            for child in children(line)
+                XML.nodetype(child) == XML.Element || continue
+                name = lowercase(tag(child))
                 # first(child) relied on LazyNode iteration, removed in XML.jl 0.4;
                 # go through children (works on both 0.3 and 0.4)
                 grandchildren = children(child)
@@ -227,31 +217,53 @@ function parse_optical_ades(text::String; eop::EOPIAU = EOP_IAU2000A)
                 v = XML.value(first(grandchildren))
                 isnothing(v) && continue
                 x = strip(v)
-                df[i, name] = adesparse(name, type, x)
+                $(
+                    let
+                        fields = [n for n in fieldnames(OpticalADES{Float64}) if n ∉ (:timeofday, :source)]
+                        expr = :(nothing)
+                        for name in reverse(fields)
+                            T = fieldtype(OpticalADES{Float64}, name)
+                            sname = string(name)
+                            qname = QuoteNode(name)
+                            expr = :(
+                                if name == $sname
+                                    $(name) = adesparse($qname, $T, x)
+                                else
+                                    $expr
+                                end
+                            )
+                        end
+                        expr
+                    end
+                )
             end
+            # Satellite observatories
+            if istwoliner(stn)
+                frame = isempty(sys) ? stn.frame : sys
+                coords = SVector{3, Float64}(pos1, pos2, pos3)
+                stn = ObservatoryMPC(stn; frame, coords)
+            end
+            # Occultation observations
+            if mode == "OCC"
+                dec = decstar + deltadec
+                ra = rastar + deltara / cos(dec)
+            end
+            # Source string
+            source = XML.write(line)
+            # Time of day
+            timeofday = TimeOfDay(stn, obstime; eop)
+            # Assemble observation
+            optical[i] = OpticalADES{Float64}($(
+                [name for name in fieldnames(OpticalADES{Float64})]...
+            ))
         end
-    end
-    # Satellite observatories
-    mask = findall(istwoliner, df.stn)
-    for i in mask
-        frame = isempty(df.sys[i]) ? df.stn[i].frame : df.sys[i]
-        coords = SVector{3, Float64}(df.pos1[i], df.pos2[i], df.pos3[i])
-        df.stn[i] = ObservatoryMPC(df.stn[i]; frame, coords)
-    end
-    # Occultation observations
-    mask = findall(==("OCC"), df.mode)
-    for i in mask
-        df.dec[i] = df.decstar[i] + df.deltadec[i]
-        df.ra[i] = df.rastar[i] + df.deltara[i] / cos(df.dec[i])
-    end
-    # Source string
-    df.source .= XML.write.(obs)
-    # Time of day
-    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.stn, df.obstime)
-    # Parse observations
-    optical = OpticalADES.(eachrow(df))
+        # Eliminate repeated entries
+        unique!(optical)
+        # Sort by date
+        sort!(optical)
 
-    return optical
+        return optical
+    end
 end
 
 """

--- a/src/astrometry/opticalmpc80.jl
+++ b/src/astrometry/opticalmpc80.jl
@@ -148,59 +148,55 @@ function mpc80parse(name, ::Type{T}, x) where {T <: Real}
     end
 end
 
-OpticalMPC80(r::DataFrameRow) = OpticalMPC80{Float64}(
-    r.number, r.desig, r.discovery, r.note1, r.note2, r.date, r.ra,
-    r.dec, r.info1, r.mag, r.band, r.catalogue, r.info2, r.observatory,
-    r.source, r.timeofday
-)
-
-function parse_optical_mpc80(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
-    # File reader
-    reader = MPC80FileReader(text)
-    L = length(reader.optical)
-    # Construct DataFrame
-    R = OpticalMPC80{Float64}
-    names, types = fieldnames(R), fieldtypes(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(reader.optical)
-        for (name, type, idxs) in zip(names, types, MPC80_OPTICAL_COLUMNS)
-            x = strip(view(line, idxs))
-            df[i, name] = mpc80parse(name, type, x)
+@eval begin
+    function parse_optical_mpc80(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
+        # File reader
+        reader = MPC80FileReader(text)
+        isempty(reader.optical) && return OpticalMPC80{Float64}[]
+        # Main parse loop
+        optical = Vector{OpticalMPC80{Float64}}(undef, length(reader.optical))
+        for (i, line) in enumerate(reader.optical)
+            $([:(
+                $(name) = mpc80parse(
+                    $(QuoteNode(name)),
+                    $(fieldtype(OpticalMPC80{Float64}, name)),
+                    strip(view(line, $idxs))
+                )
+            ) for (name, idxs) in zip(fieldnames(OpticalMPC80{Float64}), MPC80_OPTICAL_COLUMNS)
+            if name ∉ (:source, :timeofday)]...)
+            # Two line observations (skip observations with a 'x' note, e.g. 2010 BO127)
+            if istwoliner(observatory) && note2 != 'x'
+                subline = view(line, 82:162)
+                I1, I2, I3 = isroving(observatory) ? (35:44, 46:55, 57:61) :
+                    (35:45, 47:57, 59:69)
+                if isoccultation(observatory) || issatellite(observatory)
+                    frame = subline[33] == '1' ? "ICRF_KM" : "ICRF_AU"
+                else
+                    frame = observatory.frame
+                end
+                coords = SVector{3, Float64}(
+                    parse(Float64, replace(view(subline, I1), " " => "")),
+                    parse(Float64, replace(view(subline, I2), " " => "")),
+                    parse(Float64, replace(view(subline, I3), " " => ""))
+                )
+                observatory = ObservatoryMPC(observatory; frame, coords)
+            end
+            # Source string
+            source = string(line)
+            # Time of day
+            timeofday = TimeOfDay(observatory, date; eop)
+            # Assemble observation
+            optical[i] = OpticalMPC80{Float64}($(
+                    [name for name in fieldnames(OpticalMPC80{Float64})]...
+            ))
         end
-    end
-    # Two line observations
-    mask = findall(istwoliner, df.observatory)
-    for i in mask
-        # Skip observations with a 'x' note (e.g. 2010 BO127)
-        df.note2[i] == 'x' && continue
-        obs = df.observatory[i]
-        line = view(reader.optical[i], 82:162)
-        I1, I2, I3 = isroving(obs) ? (35:44, 46:55, 57:61) : (35:45, 47:57, 59:69)
-        if isoccultation(obs) || issatellite(obs)
-            frame = line[33] == '1' ? "ICRF_KM" : "ICRF_AU"
-        else
-            frame = obs.frame
-        end
-        coords = SVector{3, Float64}(
-            parse(Float64, replace(view(line, I1), " " => "")),
-            parse(Float64, replace(view(line, I2), " " => "")),
-            parse(Float64, replace(view(line, I3), " " => ""))
-        )
-        df.observatory[i] = ObservatoryMPC(obs; frame, coords)
-    end
-    # Source string
-    df.source .= reader.optical
-    # Time of day
-    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.observatory, df.date)
-    # Parse observations
-    optical = OpticalMPC80.(eachrow(df))
-    # Eliminate repeated entries
-    unique!(optical)
-    # Sort by date
-    sort!(optical)
+        # Eliminate repeated entries
+        unique!(optical)
+        # Sort by date
+        sort!(optical)
 
-    return optical
+        return optical
+    end
 end
 
 """

--- a/src/astrometry/opticalrwo.jl
+++ b/src/astrometry/opticalrwo.jl
@@ -232,64 +232,59 @@ function rwoparse(_, ::Type{Bool}, x)
     end
 end
 
-OpticalRWO(r::DataFrameRow) = OpticalRWO{Float64}(
-    r.design, r.K, r.T, r.N, r.date, r.date_accuracy, r.ra, r.ra_accuracy,
-    r.ra_rms, r.ra_flag, r.ra_bias, r.ra_resid, r.dec, r.dec_accuracy, r.dec_rms,
-    r.dec_flag, r.dec_bias, r.dec_resid, r.mag, r.mag_band, r.mag_rms, r.mag_resid,
-    r.catalogue, r.observatory, r.chi, r.sel_A, r.sel_M, r.source, r.header, r.timeofday
-)
-
-function parse_optical_rwo(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
-    # File reader
-    reader = RWOFileReader(text)
-    L = length(reader.optical)
-    shift = get_rwo_optical_shift(reader.source)
-    columns = get_rwo_optical_columns(reader.source)
-    # Construct DataFrame
-    R = OpticalRWO{Float64}
-    names, types = fieldnames(R), fieldtypes(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(reader.optical)
-        for (name, type, idxs) in zip(names, types, columns)
-            x = strip(view(line, idxs))
-            df[i, name] = rwoparse(name, type, x)
+@eval begin
+    function parse_optical_rwo(text::AbstractString; eop::EOPIAU = EOP_IAU2000A)
+        # File reader
+        reader = RWOFileReader(text)
+        shift = get_rwo_optical_shift(reader.source)
+        columns = get_rwo_optical_columns(reader.source)
+        isempty(reader.optical) && return OpticalRWO{Float64}[]
+        # Main parse loop
+        optical = Vector{OpticalRWO{Float64}}(undef, length(reader.optical))
+        for (i, line) in enumerate(reader.optical)
+            $([:(
+                $(name) = rwoparse(
+                    $(QuoteNode(name)),
+                    $(fieldtype(OpticalRWO{Float64}, name)),
+                    strip(view(line, columns[$c]))
+                )
+            ) for (c, name) in enumerate(
+                [n for n in fieldnames(OpticalRWO{Float64}) if n ∉ (:source, :header, :timeofday)]
+            )]...)
+            # Two line observations (skip observations with a 'x' note, e.g. 2010 BO127)
+            if istwoliner(observatory) && T != 'x'
+                subline = view(line, 199+shift:length(line))
+                if isoccultation(observatory) || issatellite(observatory)
+                    frame = subline[35+shift] == '1' ? "ICRF_KM" : "ICRF_AU"
+                else
+                    frame = observatory.frame
+                end
+                vals = split(subline)
+                coords = SVector{3, Float64}(
+                    parse(Float64, vals[end-3]),
+                    parse(Float64, vals[end-2]),
+                    parse(Float64, vals[end-1])
+                )
+                observatory = ObservatoryMPC(observatory; frame, coords)
+            end
+            # Source string
+            source = string(line)
+            # File header
+            header = string(reader.header)
+            # Time of day
+            timeofday = TimeOfDay(observatory, date; eop)
+            # Assemble observation
+            optical[i] = OpticalRWO{Float64}($(
+                [name for name in fieldnames(OpticalRWO{Float64})]...
+            ))
         end
-    end
-    # Two-line observations
-    mask = findall(istwoliner, df.observatory)
-    for i in mask
-        # Skip observations with a 'x' note (e.g. 2010 BO127)
-        df.T[i] == 'x' && continue
-        obs = df.observatory[i]
-        line = view(reader.optical[i], 199+shift:length(reader.optical[i]))
-        if isoccultation(obs) || issatellite(obs)
-            frame = line[35+shift] == '1' ? "ICRF_KM" : "ICRF_AU"
-        else
-            frame = obs.frame
-        end
-        vals = split(line)
-        coords = SVector{3, Float64}(
-            parse(Float64, vals[end-3]),
-            parse(Float64, vals[end-2]),
-            parse(Float64, vals[end-1])
-        )
-        df.observatory[i] = ObservatoryMPC(obs; frame, coords)
-    end
-    # Source string
-    df.source .= reader.optical
-    # File header
-    df.header .= reader.header
-    # Time of day
-    tmap!((x, y) -> TimeOfDay(x, y; eop), df.timeofday, df.observatory, df.date)
-    # Parse observations
-    optical = OpticalRWO.(eachrow(df))
-    # Eliminate repeated entries
-    unique!(optical)
-    # Sort by date
-    sort!(optical)
+        # Eliminate repeated entries
+        unique!(optical)
+        # Sort by date
+        sort!(optical)
 
-    return optical
+        return optical
+    end
 end
 
 """

--- a/src/astrometry/radarjpl.jl
+++ b/src/astrometry/radarjpl.jl
@@ -60,36 +60,37 @@ jplparse(_, ::Type{DateTime}, x) = DateTime(x, RADAR_JPL_DATEFORMAT)
 jplparse(_, ::Type{ObservatoryMPC{T}}, x) where {T <: Real} =
     search_observatory_code(JPL_TO_MPC_OBSCODES[x])
 
-RadarJPL(r::DataFrameRow) = RadarJPL{Float64}(
-    r.des, r.epoch, r.value, r.sigma, r.units, r.freq,
-    r.rcvr, r.xmit, r.bp
-)
-
-function parse_radar_jpl(text::AbstractString)
-    # Parse JSON
-    dict = JSON.parse(text)
-    filter!(x -> haskey(JPL_TO_MPC_OBSCODES, x[7]) && haskey(JPL_TO_MPC_OBSCODES, x[8]),
-            dict["data"])
-    L = length(dict["data"])
-    iszero(L) && return RadarJPL{Float64}[]
-    # Construct DataFrame
-    R = RadarJPL{Float64}
-    names, types = fieldnames(R), fieldtypes(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(dict["data"])
-        for (name, type, x) in zip(names, types, line)
-            df[i, name] = jplparse(name, type, x)
+@eval begin
+    function parse_radar_jpl(text::AbstractString)
+        # Parse JSON
+        dict = JSON.parse(text)
+        filter!(x -> haskey(JPL_TO_MPC_OBSCODES, x[7]) && haskey(JPL_TO_MPC_OBSCODES, x[8]),
+                dict["data"])
+        isempty(dict["data"]) && return RadarJPL{Float64}[]
+        # Main parse loop
+        radar = Vector{RadarJPL{Float64}}(undef, length(dict["data"]))
+        for (i, line) in enumerate(dict["data"])
+            $([:(
+                $(name) = jplparse(
+                    $(QuoteNode(name)),
+                    $(fieldtype(RadarJPL{Float64}, name)),
+                    line[$c]
+                )
+            ) for (c, name) in enumerate(
+                [n for n in fieldnames(RadarJPL{Float64})]
+            )]...)
+            # Assemble observation
+            radar[i] = RadarJPL{Float64}($(
+                [name for name in fieldnames(RadarJPL{Float64})]...
+            ))
         end
-    end
-    # Parse observations
-    radar = RadarJPL.(eachrow(df))
-    # Eliminate repeated entries
-    unique!(radar)
-    # Sort by date
-    sort!(radar)
+        # Eliminate repeated entries
+        unique!(radar)
+        # Sort by date
+        sort!(radar)
 
-    return radar
+        return radar
+    end
 end
 
 """

--- a/src/astrometry/radarresidual.jl
+++ b/src/astrometry/radarresidual.jl
@@ -435,9 +435,11 @@ function compute_delay(observatory::ObservatoryMPC{T}, t_r_utc::DateTime; tord::
     xva1et0 = xva(et_r_secs_0)[1]
     # et_r_secs_0 as a Taylor polynomial
     et_r_secs = Taylor1([et_r_secs_0,one(et_r_secs_0)].*one(xva1et0), tord)
+    utc_r_secs = et_r_secs - tdb_utc(et_r_secs)
+    utc_r_days = JD_J2000 + utc_r_secs / daysec
     # Compute geocentric position/velocity of receiving antenna in
     # inertial frame [km, km/sec]
-    RV_r = obsposvelECI(observatory, et_r_secs)
+    RV_r = obsposvelECI(observatory, utc_r_days)
     R_r = RV_r[1:3]
     # Earth's barycentric position and velocity at receive time
     r_e_t_r = xve(et_r_secs)[1:3]

--- a/src/astrometry/radarrwo.jl
+++ b/src/astrometry/radarrwo.jl
@@ -155,39 +155,40 @@ end
 get_rwo_radar_columns(x::Symbol) = x == :NEOCC ?
     NEOCC_RADAR_COLUMNS : NEODyS2_RADAR_COLUMNS
 
-RadarRWO(r::DataFrameRow) = RadarRWO{Float64}(
-    r.design, r.K, r.T, r.N, r.date, r.measure, r.accuracy, r.rms, r.flag,
-    r.bias, r.resid, r.trx, r.rcx, r.chi, r.S, r.source, r.header
-)
-
-function parse_radar_rwo(text::String)
-    # File reader
-    reader = RWOFileReader(text)
-    L = length(reader.radar)
-    columns = get_rwo_radar_columns(reader.source)
-    # Construct DataFrame
-    R = RadarRWO{Float64}
-    names, types = fieldnames(R), fieldtypes(R)
-    df = DataFrame([fill(astrometrydefault(fieldtype(R, name)), L) for name in names],
-        collect(names))
-    for (i, line) in enumerate(reader.radar)
-        for (name, type, idxs) in zip(names, types, columns)
-            x = strip(view(line, idxs))
-            df[i, name] = rwoparse(name, type, x)
+@eval begin
+    function parse_radar_rwo(text::AbstractString)
+        # File reader
+        reader = RWOFileReader(text)
+        columns = get_rwo_radar_columns(reader.source)
+        isempty(reader.radar) && return RadarRWO{Float64}[]
+        # Main parse loop
+        radar = Vector{RadarRWO{Float64}}(undef, length(reader.radar))
+        for (i, line) in enumerate(reader.radar)
+            $([:(
+                $(name) = rwoparse(
+                    $(QuoteNode(name)),
+                    $(fieldtype(RadarRWO{Float64}, name)),
+                    strip(view(line, columns[$c]))
+                )
+            ) for (c, name) in enumerate(
+                [n for n in fieldnames(RadarRWO{Float64}) if n ∉ (:source, :header)]
+            )]...)
+            # Source string
+            source = string(line)
+            # File header
+            header = string(reader.header)
+            # Assemble observation
+            radar[i] = RadarRWO{Float64}($(
+                    [name for name in fieldnames(RadarRWO{Float64})]...
+            ))
         end
-    end
-    # Source string
-    df.source = reader.radar
-    # File header
-    df.header .= reader.header
-    # Parse observations
-    radar = RadarRWO.(eachrow(df))
-    # Eliminate repeated entries
-    unique!(radar)
-    # Sort by date
-    sort!(radar)
+        # Eliminate repeated entries
+        unique!(radar)
+        # Sort by date
+        sort!(radar)
 
-    return radar
+        return radar
+    end
 end
 
 """

--- a/src/astrometry/topocentric.jl
+++ b/src/astrometry/topocentric.jl
@@ -43,7 +43,7 @@ function TimeOfDay(observatory::ObservatoryMPC, date::DateTime; eop::EOPIAU = EO
         return TimeOfDay(:satellite, date, date, 0)
     end
     # Hours from UTC
-    utc = hours_from_UTC(observatory, dtutc2et(date); eop)
+    utc = hours_from_UTC(observatory, datetime2julian(date); eop)
     # Today's sunrise / sunset
     today = sunriseset(observatory, date; eop)
     # Yesterday's sunrise / sunset
@@ -65,16 +65,16 @@ end
 # Return the naive hour difference between longitude `lon` [rad] and UTC.
 hours_from_UTC(lon::Real) = ceil(Int, 12*lon/π - 0.5)
 
-function hours_from_UTC(observatory::ObservatoryMPC, et::Number;
+function hours_from_UTC(observatory::ObservatoryMPC, jd_utc::Number;
                         eop::EOPIAU = EOP_IAU2000A)
-    lon, _ = lonlat(observatory, et; eop)
+    lon, _ = lonlat(observatory, jd_utc; eop)
     return hours_from_UTC(lon)
 end
 
 # Return the geocentric longitude and latitude [rad] of an observatory.
-function lonlat(observatory::ObservatoryMPC, et::Number; eop::EOPIAU = EOP_IAU2000A)
+function lonlat(observatory::ObservatoryMPC, jd_utc::Number; eop::EOPIAU = EOP_IAU2000A)
     # Observer's position in ITRF (ECEF) frame [m]
-    posECEF = obsposECEF(observatory, et; eop) * 1_000
+    posECEF = obsposECEF(observatory, jd_utc; eop) * 1_000
     # Transform from ITRF (ECEF) [m] to Geocentric [m]
     lat, lon, _ = ecef_to_geocentric(posECEF)
 
@@ -98,7 +98,7 @@ function sunriseset(observatory::ObservatoryMPC, date::DateTime;
     δ = 0.006918 - 0.399912*cos(γ) + 0.070257*sin(γ) - 0.006758*cos(2γ) + 0.000907*sin(2γ)
         - 0.002697*cos(3γ) + 0.00148*sin(3γ)
     # Longitude and latitude [rad]
-    lon, lat = lonlat(observatory, dtutc2et(date); eop)
+    lon, lat = lonlat(observatory, datetime2julian(date); eop)
     # Solar hour angle [deg]
     ha_sunrise = acosd(cosd(90.833)/cos(lat)/cos(δ) - tan(lat)*tan(δ))
     ha_sunset = -ha_sunrise
@@ -128,15 +128,15 @@ Earth-Centered Earth-Fixed (ECEF) reference frame.
     (default: `EOP_IAU2000A`).
 """
 obsposECEF(x::AbstractAstrometryObservation; eop::EOPIAU = EOP_IAU2000A) =
-    obsposECEF(observatory(x), dtutc2et(x); eop)
+    obsposECEF(observatory(x), datetime2julian(date(x)); eop)
 
-obsposECEF(obs::ObservatoryMPC, et::Number; eop::EOPIAU = EOP_IAU2000A) =
-    obsposECEF(Val(Symbol(obs.frame)), obs.coords, et; eop)
+obsposECEF(obs::ObservatoryMPC, jd_utc::Number; eop::EOPIAU = EOP_IAU2000A) =
+    obsposECEF(Val(Symbol(obs.frame)), obs.coords, jd_utc; eop)
 
-function obsposECEF(::Val{:MPC}, coords::SVector{3, T}, et::U;
-                    eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
+function obsposECEF(::Val{:MPC}, coords::SVector{3}, jd_utc::Number;
+                    eop::EOPIAU = EOP_IAU2000A)
     # One with correct type (and order)
-    oneU = one(et)
+    oneU = one(jd_utc)
     # Cilindrical coordinates of the observer's position in ITRF (ECEF) frame
     # λ: longitude East of the prime meridian [rad]
     # u: distance from spin axis ( ρ * cos(ϕ')) [km]
@@ -149,23 +149,19 @@ function obsposECEF(::Val{:MPC}, coords::SVector{3, T}, et::U;
     x = u * cos(λ)
     y = u * sin(λ)
     z = v
-    posECEF = SVector{3, U}(x * oneU, y * oneU, z * oneU)
+    posECEF = SVector{3, typeof(jd_utc)}(x * oneU, y * oneU, z * oneU)
 
     return posECEF
 end
 
-function obsposECEF(::Val{:ICRF_KM}, coords::SVector{3, T}, et::U;
-                    eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
+function obsposECEF(::Val{:ICRF_KM}, coords::SVector{3}, jd_utc::Number;
+                    eop::EOPIAU = EOP_IAU2000A)
     # Zero and one with correct type (and order)
-    zeroU, oneU = zero(et), one(et)
-    # UTC seconds
-    utc_secs = et - tdb_utc(et)
-    # Julian days UTC
-    jd_utc = JD_J2000 + utc_secs/daysec
+    zeroU, oneU = zero(jd_utc), one(jd_utc)
     # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
     posECI = coords * oneU
-    velECI = SVector{3, U}(zeroU, zeroU, zeroU)
-    accECI = SVector{3, U}(zeroU, zeroU, zeroU)
+    velECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    accECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
     posvelECI = OrbitStateVector(jd_utc, posECI, velECI, accECI)
     # Transform state vector from:
     # GCRF: Geocentric Celestial Reference Frame (ECI)
@@ -176,18 +172,14 @@ function obsposECEF(::Val{:ICRF_KM}, coords::SVector{3, T}, et::U;
     return posvelECEF.r
 end
 
-function obsposECEF(::Val{:ICRF_AU}, coords::SVector{3, T}, et::U;
-                    eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
+function obsposECEF(::Val{:ICRF_AU}, coords::SVector{3}, jd_utc::Number;
+                    eop::EOPIAU = EOP_IAU2000A)
     # Zero and one with correct type (and order)
-    zeroU, oneU = zero(et), one(et)
-    # UTC seconds
-    utc_secs = et - tdb_utc(et)
-    # Julian days UTC
-    jd_utc = JD_J2000 + utc_secs/daysec
+    zeroU, oneU = zero(jd_utc), one(jd_utc)
     # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
     posECI = coords * oneU * au
-    velECI = SVector{3, U}(zeroU, zeroU, zeroU)
-    accECI = SVector{3, U}(zeroU, zeroU, zeroU)
+    velECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    accECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
     posvelECI = OrbitStateVector(jd_utc, posECI, velECI, accECI)
     # Transform state vector from:
     # GCRF: Geocentric Celestial Reference Frame (ECI)
@@ -198,10 +190,10 @@ function obsposECEF(::Val{:ICRF_AU}, coords::SVector{3, T}, et::U;
     return posvelECEF.r
 end
 
-function obsposECEF(::Val{:WGS84}, coords::SVector{3, T}, et::U;
-                    eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
+function obsposECEF(::Val{:WGS84}, coords::SVector{3}, jd_utc::Number;
+                    eop::EOPIAU = EOP_IAU2000A)
     # One with correct type (and order)
-    oneU = one(et)
+    oneU = one(jd_utc)
     # Geodetic coordinates of the observer's position in WGS84 (ECEF) frame
     # lon: East longitude [rad]
     # lat: latitude [rad]
@@ -213,6 +205,89 @@ function obsposECEF(::Val{:WGS84}, coords::SVector{3, T}, et::U;
     posECEF = geodetic_to_ecef(lat, lon, alt) / 1_000
 
     return posECEF
+end
+
+"""
+    obsposvelECI(::AbstractOpticalAstrometry; kwargs...)
+
+Return the observer's geocentric cartesian state vector [km, km/sec] in
+Earth-Centered Inertial (ECI) reference frame.
+
+# Keyword argument
+
+- `eop::Union{EopIau1980, EopIau2000A}`: Earth Orientation Parameters
+    (default: `EOP_IAU2000A`).
+
+# Extended help
+
+By default, the IAU200A Earth orientation model is used to transform
+from  Earth-centered, Earth-fixed (ECEF) frame to ECI frame. Other Earth
+orientation  models, such as the IAU1976/80 model, can be used by importing
+the `SatelliteToolboxTransformations.EopIau1980` type and passing it to the
+`eop` keyword argument in the function call.
+"""
+obsposvelECI(x::AbstractAstrometryObservation; eop::EOPIAU = EOP_IAU2000A) =
+    obsposvelECI(observatory(x), datetime2julian(date(x)); eop)
+
+obsposvelECI(obs::ObservatoryMPC, jd_utc::Number; eop::EOPIAU = EOP_IAU2000A) =
+    obsposvelECI(Val(Symbol(obs.frame)), obs.coords, jd_utc; eop)
+
+function obsposvelECI(::Val{:MPC}, coords::SVector{3}, jd_utc::Number;
+                      eop::EOPIAU = EOP_IAU2000A)
+    # Zero of correct type (and order)
+    zeroU = zero(jd_utc)
+    # Cartesian coordinates of the observer's state vector in ITRF (ECEF) frame [km]
+    posECEF = obsposECEF(Val(:MPC), coords, jd_utc; eop)
+    velECEF = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    accECEF = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    posvelECEF = OrbitStateVector(jd_utc, posECEF, velECEF, accECEF)
+    # Transform state vector from:
+    # ITRF: International Terrestrial Reference Frame (ECEF)
+    # to:
+    # GCRF: Geocentric Celestial Reference Frame (ECI)
+    posvelECI = sv_ecef_to_eci(posvelECEF, Val(:ITRF), Val(:GCRF), jd_utc, eop)
+
+    return vcat(posvelECI.r, posvelECI.v)
+end
+
+function obsposvelECI(::Val{:ICRF_KM}, coords::SVector{3}, jd_utc::Number;
+                      eop::EOPIAU = EOP_IAU2000A)
+    # One with correct type (and order)
+    zeroU, oneU = zero(jd_utc), one(jd_utc)
+    # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
+    posECI = coords * oneU
+    velECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+
+    return vcat(posECI, velECI)
+end
+
+function obsposvelECI(::Val{:ICRF_AU}, coords::SVector{3}, jd_utc::Number;
+                      eop::EOPIAU = EOP_IAU2000A)
+    # One with correct type (and order)
+    zeroU, oneU = zero(jd_utc), one(jd_utc)
+    # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
+    posECI = coords * oneU * au
+    velECI = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+
+    return vcat(posECI, velECI)
+end
+
+function obsposvelECI(::Val{:WGS84}, coords::SVector{3}, jd_utc::Number;
+                      eop::EOPIAU = EOP_IAU2000A)
+    # Zero of correct type (and order)
+    zeroU = zero(jd_utc)
+    # Cartesian coordinates of the observer's state vector in ITRF (ECEF) frame [km]
+    posECEF = obsposECEF(Val(:WGS84), coords, jd_utc; eop)
+    velECEF = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    accECEF = SVector{3, typeof(jd_utc)}(zeroU, zeroU, zeroU)
+    posvelECEF = OrbitStateVector(jd_utc, posECEF, velECEF, accECEF)
+    # Transform state vector from:
+    # ITRF: International Terrestrial Reference Frame (ECEF)
+    # to:
+    # GCRF: Geocentric Celestial Reference Frame (ECI)
+    posvelECI = sv_ecef_to_eci(posvelECEF, Val(:ITRF), Val(:GCRF), jd_utc, eop)
+
+    return vcat(posvelECI.r, posvelECI.v)
 end
 
 # TODO: avoid sv_ecef_to_ecef and sv_ecef_to_eci overloads by defining proper product
@@ -280,97 +355,6 @@ for EOP in (:Nothing, :EopIau1980, :EopIau2000A)
     end
 end
 =#
-
-"""
-    obsposvelECI(::AbstractOpticalAstrometry; kwargs...)
-
-Return the observer's geocentric cartesian state vector [km, km/sec] in
-Earth-Centered Inertial (ECI) reference frame.
-
-# Keyword argument
-
-- `eop::Union{EopIau1980, EopIau2000A}`: Earth Orientation Parameters
-    (default: `EOP_IAU2000A`).
-
-# Extended help
-
-By default, the IAU200A Earth orientation model is used to transform
-from  Earth-centered, Earth-fixed (ECEF) frame to ECI frame. Other Earth
-orientation  models, such as the IAU1976/80 model, can be used by importing
-the `SatelliteToolboxTransformations.EopIau1980` type and passing it to the
-`eop` keyword argument in the function call.
-"""
-obsposvelECI(x::AbstractAstrometryObservation; eop::EOPIAU = EOP_IAU2000A) =
-    obsposvelECI(observatory(x), dtutc2et(x); eop)
-
-obsposvelECI(obs::ObservatoryMPC, et::Number; eop::EOPIAU = EOP_IAU2000A) =
-    obsposvelECI(Val(Symbol(obs.frame)), obs.coords, et; eop)
-
-function obsposvelECI(::Val{:MPC}, coords::SVector{3, T}, et::U;
-                      eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
-    # Zero of correct type (and order)
-    zeroU = zero(et)
-    # UTC seconds
-    utc_secs = et - tdb_utc(et)
-    # Julian days UTC
-    jd_utc = JD_J2000 + utc_secs/daysec
-    # Cartesian coordinates of the observer's state vector in ITRF (ECEF) frame [km]
-    posECEF = obsposECEF(Val(:MPC), coords, et; eop)
-    velECEF = SVector{3, U}(zeroU, zeroU, zeroU)
-    accECEF = SVector{3, U}(zeroU, zeroU, zeroU)
-    posvelECEF = OrbitStateVector(jd_utc, posECEF, velECEF, accECEF)
-    # Transform state vector from:
-    # ITRF: International Terrestrial Reference Frame (ECEF)
-    # to:
-    # GCRF: Geocentric Celestial Reference Frame (ECI)
-    posvelECI = sv_ecef_to_eci(posvelECEF, Val(:ITRF), Val(:GCRF), jd_utc, eop)
-
-    return vcat(posvelECI.r, posvelECI.v)
-end
-
-function obsposvelECI(::Val{:ICRF_KM}, coords::SVector{3, T}, et::U;
-                      eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
-    # One with correct type (and order)
-    zeroU, oneU = zero(et), one(et)
-    # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
-    posECI = coords * oneU
-    velECI = SVector{3, U}(zeroU, zeroU, zeroU)
-
-    return vcat(posECI, velECI)
-end
-
-function obsposvelECI(::Val{:ICRF_AU}, coords::SVector{3, T}, et::U;
-                      eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
-    # One with correct type (and order)
-    zeroU, oneU = zero(et), one(et)
-    # Cartesian coordinates of the observer's state vector in GCRF (ECI) frame [km]
-    posECI = coords * oneU * au
-    velECI = SVector{3, U}(zeroU, zeroU, zeroU)
-
-    return vcat(posECI, velECI)
-end
-
-function obsposvelECI(::Val{:WGS84}, coords::SVector{3, T}, et::U;
-                      eop::EOPIAU = EOP_IAU2000A) where {T <: Real, U <: Number}
-    # Zero of correct type (and order)
-    zeroU = zero(et)
-    # UTC seconds
-    utc_secs = et - tdb_utc(et)
-    # Julian days UTC
-    jd_utc = JD_J2000 + utc_secs/daysec
-    # Cartesian coordinates of the observer's state vector in ITRF (ECEF) frame [km]
-    posECEF = obsposECEF(Val(:WGS84), coords, et; eop)
-    velECEF = SVector{3, U}(zeroU, zeroU, zeroU)
-    accECEF = SVector{3, U}(zeroU, zeroU, zeroU)
-    posvelECEF = OrbitStateVector(jd_utc, posECEF, velECEF, accECEF)
-    # Transform state vector from:
-    # ITRF: International Terrestrial Reference Frame (ECEF)
-    # to:
-    # GCRF: Geocentric Celestial Reference Frame (ECI)
-    posvelECI = sv_ecef_to_eci(posvelECEF, Val(:ITRF), Val(:GCRF), jd_utc, eop)
-
-    return vcat(posvelECI.r, posvelECI.v)
-end
 
 # Convert from the fixed-width USNO format to the IERS csv format
 # read by SatelliteToolboxTransformations

--- a/src/orbitdetermination/admissible/constructors.jl
+++ b/src/orbitdetermination/admissible/constructors.jl
@@ -44,10 +44,10 @@ function AdmissibleRegion(date::DateTime, α::T, δ::T, v_α::T, v_δ::T,
     @unpack eph_ea, eph_su, H_max, a_max = params
     # Topocentric unit vector and partials
     ρ, ρ_α, ρ_δ = topounitpdv(α, δ)
-    # Time of observation [days (et seconds) since J2000]
-    t_days, t_et = dtutc2days(date), dtutc2et(date)
+    # Time of observation [days since J2000 TDB, Julian days UTC]
+    t_days, jd_utc = dtutc2days(date), datetime2julian(date)
     # Heliocentric position of the observer
-    q = eph_ea(t_days) + kmsec2auday(obsposvelECI(observatory, t_et)) - eph_su(t_days)
+    q = eph_ea(t_days) + kmsec2auday(obsposvelECI(observatory, jd_utc)) - eph_su(t_days)
     # Admissible region coefficients
     coeffs = arcoeffs(α, δ, v_α, v_δ, ρ, ρ_α, ρ_δ, q)
     # Maximum range (heliocentric energy constraint)

--- a/src/orbitdetermination/admissible/projection.jl
+++ b/src/orbitdetermination/admissible/projection.jl
@@ -74,16 +74,17 @@ function attr2bary(A::AdmissibleRegion{T}, a::Vector{U},
     # Unfold
     α, δ, v_α, v_δ, ρ, v_ρ = a
     # Admissible region reference epoch
-    # Note: we concluded both t and et should not include the relativistic
-    # correction -ρ/c for consistency (05/12/2025)
+    # Note: we concluded both t and jd_utc should not include the relativistic
+    # correction -ρ/c for consistency (20/08/2026)
     t = dtutc2days(A.date) # - ρ / c_au_per_day
-    # TO DO: `et::TaylorN` is too slow for `mmov` due to
+    # TO DO: `jd_utc::TaylorN` is too slow for `mmov` due to
     # SatelliteToolboxTransformations overloads in src/observations/topocentric.jl
-    et = dtutc2et(A.date) # - cte(cte(ρ)) / c_au_per_sec
+    jd_utc = datetime2julian(A.date) # - cte(cte(ρ)) / c_au_per_day
     # Line of sight vectors
     ρ_unit, ρ_α, ρ_δ = topounitpdv(α, δ)
     # Heliocentric position of the observer
-    q = params.eph_ea(t) + kmsec2auday(obsposvelECI(A.observatory, et)) - params.eph_su(t)
+    q = params.eph_ea(t) + kmsec2auday(obsposvelECI(A.observatory, jd_utc)) -
+        params.eph_su(t)
     # Barycentric position
     r = q[1:3] + ρ * ρ_unit + params.eph_su(t)[1:3]
     # Barycentric velocity

--- a/src/orbitdetermination/preliminary/gauss.jl
+++ b/src/orbitdetermination/preliminary/gauss.jl
@@ -225,9 +225,9 @@ function gaussmethod(observatories::Vector{ObservatoryMPC{T}}, dates::Vector{Dat
         "Gauss method requires exactly three observations"
     # Check observations are in temporal order
     @assert issorted(dates) "Observations must be in temporal order"
-    # Times of observation [et, days since J2000]
-    t_et = dtutc2et.(dates)
-    t_days = t_et ./ daysec
+    # Times of observation [Julian date UTC, days since J2000 TDB]
+    jds_utc = datetime2julian.(dates)
+    t_days = dtutc2et.(dates) ./ daysec
     # Time intervals
     τ_1 = t_days[1] - t_days[2]
     τ_3 = t_days[3] - t_days[2]
@@ -235,7 +235,7 @@ function gaussmethod(observatories::Vector{ObservatoryMPC{T}}, dates::Vector{Dat
     # Topocentric (line-of-sight) unit vectors
     ρ_vec = reduce(hcat, topounit.(α, δ))
     # Geocentric state vector of the observer [au, au/day]
-    g_vec = @. kmsec2auday(obsposvelECI(observatories, t_et))
+    g_vec = @. kmsec2auday(obsposvelECI(observatories, jds_utc))
     # Heliocentric state vector of the Earth [au, au/day]
     G_vec = @. params.eph_ea(t_days) - params.eph_su(t_days)
     # Observer's heliocentric positions [au, au/day]


### PR DESCRIPTION
This PR optimizes the parsing of optical and radar astrometry by:
- Avoiding the conversion between UTC and TDB in the construction of `TimeOfDay` as well as in the `obsposECEF` and `obsposvelECI` functions. As a result, the latter two now take the Julia date [UTC] as an argument instead of the ephemeris seconds past J2000.
- Using metaprogramming to generate the astrometry parsing functions, thereby avoiding the construction of a DataFrame (in all cases) and the unnecesary initialization with `astrometrydefault` (in most cases).

The table below compares the performance of reading astrometry in this PR with respect to main:
| Observation type | `main` (allocations / time) | PR (allocations / time) ) | `main` / PR |
| ----------------- | -------------------------- | ----------------------- | ------------ |
| `OpticalMPC80` | 7.43 M / 2.616806 s | 3.50 M / 0.603716 s | 2.1 / 4.3 |
| `OpticalRWO` | 9.38 M / 2.943387 s | 2.95 M / 0.529729 s | 3.2 / 5.6 |
| `OpticalADES` | 10.88 M / 3.072251 s | 4.82 M / 0.789877 s | 2.3 / 3.9 |
| `NEOCPObject` |	4.63 k / 0.000652 s | 2.27 k / 0.000356 s | 2.0 / 1.8 |
| `RadarJPL` | 1.25 k / 0.000306 s | 557 / 0.000234 s | 2.2 / 1.3 |
| `RadarRWO` | 795 / 0.013095 s | 422 / 0.012653 s | 1.9 / 1.0 |