### PR TITLE
Eccentricity penalty in least squares

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -375,6 +375,11 @@ const μ_ES = PE.μ[ea] / PE.μ[su] # 1 / 328_900.5614
 # Coefficient of g1 (used in compute_radec)
 const g1coeff = 2μ_DE430[su] / c_au_per_day^2
 
+# Sigma parameter of the Rayleigh distribution of the
+# eccentricities of all asteroids recognized by the
+# MPC by September 2, 2026
+const ECCENTRICITY_RAYLEIGH_SIGMA = 0.1307950766727416
+
 # Impact monitoring
 
 # Equatorial radii of planets [au]

--- a/src/orbitdetermination/abstractorbit/preliminaryorbit.jl
+++ b/src/orbitdetermination/abstractorbit/preliminaryorbit.jl
@@ -144,6 +144,7 @@ iszero(x::GaussOrbit) = x == zero(typeof(x))
 isphysical(x::GaussOrbit) = iszero(x) ? false : all(x.ρ .> 0)
 
 # Check heliocentric energy is negative
+#=
 function isclosed(x::GaussOrbit)
     iszero(x) && return false
     # Heliocentric state vector [au, au/day]
@@ -155,6 +156,7 @@ function isclosed(x::GaussOrbit)
 
     return E <= 0
 end
+=#
 
 # Evaluate TaylorN's in deltas
 function evaldeltas(orbit::GaussOrbit{D, T, TaylorN{T}, O},

--- a/src/orbitdetermination/jtls.jl
+++ b/src/orbitdetermination/jtls.jl
@@ -151,12 +151,14 @@ function addoptical!(
         lscache::LeastSquaresCache{T}, lsmethods::Tuple,
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         res::Vector{OpticalResidual{T, TaylorN{T}}},
-        x0::Vector{T}, params::Parameters{T}
+        x0::Vector{T}, params::Parameters{T};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
     Qtol, Mtol = params.lsQtol, params.lsMtol
     while !isempty(trksout)
         extra = indices(trksout[1])
-        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods; Qtol, Mtol)
+        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods;
+                        penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -175,12 +177,14 @@ function addoptical!(
         lscache::LeastSquaresCache{T}, lsmethods::Tuple,
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         res::Vector{OpticalResidual{T, TaylorN{T}}},
-        x0::Vector{T}, params::Parameters{T}
+        x0::Vector{T}, params::Parameters{T};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
     Qtol, Mtol = params.lsQtol, params.lsMtol
     if critical_value(view(res, oidxs), fit) < params.significance && !isempty(trksout)
         extra = indices(trksout[1])
-        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods; Qtol, Mtol)
+        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods;
+                        penalty, Qtol, Mtol)
         !issuccess(fit_new) && return oidxs, fit
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -198,14 +202,15 @@ function addobservations!(
         fit::LeastSquaresFit{T}, lscache::LeastSquaresCache{T}, lsmethods::Tuple,
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         radarin::AbstractRadarVector{T}, radarout::AbstractRadarVector{T},
-        res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T}, params::Parameters{T}
+        res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T}, params::Parameters{T};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
     Qtol, Mtol = params.lsQtol, params.lsMtol
     # Add optical astrometry
     while !isempty(trksout)
         extra = indices(trksout[1])
         fit_new = tryls((res[1][oidxs ∪ extra], res[2][ridxs]), x0, lscache, lsmethods;
-                         Qtol, Mtol)
+                         penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -219,7 +224,7 @@ function addobservations!(
         extra = findfirst(==(radarout[1]), od.radar)
         isnothing(extra) && break
         fit_new = tryls((res[1][oidxs], res[2][ridxs ∪ extra]), x0, lscache, lsmethods;
-                        Qtol, Mtol)
+                        penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         radar = popfirst!(radarout)
@@ -314,8 +319,8 @@ function jtls(
     end
     # Unpack
     Qtol, Mtol = params.lsQtol, params.lsMtol
-    @unpack jtlsorder, jtlsiter, outrej, jtlsmask, χ2_rec, χ2_rej,
-            fudge, max_per = params
+    @unpack jtlsorder, jtlsiter, outrej, jtlsmask, lspenalty, eph_su,
+            χ2_rec, χ2_rej, fudge, max_per = params
     @unpack orbits, res, Qs, q00s, outs, prbuffer, lscache, orcache = buffer
     # Reference epoch [Julian days TDB]
     jd0 = meanepoch(od) + PE.J2000
@@ -325,6 +330,7 @@ function jtls(
     # Least squares methods
     x0 = zeros(T, Npar)
     lsmethods = _lsmethods(res, x0, 1:Npar)
+    penalty = lspenalty ? zero(TaylorN{T}) : nothing
     # Initial subset of astrometry for orbit fit
     trksin, trksout, oidxs = _initialtracklets(od.tracklets, orbit.tracklets)
     # Jet Transport Least Squares
@@ -340,7 +346,12 @@ function jtls(
         bwd, fwd = propres!(res, od, q0, jd0, params; buffer = prbuffer)
         isempty(res) && break
         # Orbit fit
-        fit = tryls(view(res, oidxs), x0, lscache, lsmethods; Qtol, Mtol)
+        if lspenalty
+            _q0_ = equatorial2ecliptic(q0 - eph_su(jd0 - PE.J2000))
+            e = eccentricity(_q0_..., μ_S, zero(T))
+            penalty = eccentricitypenalty(e)
+        end
+        fit = tryls(view(res, oidxs), x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break
         # Incrementally add observations to fit
         oidxs, fit = addoptical!(Val(mode), oidxs, fit, lscache, lsmethods,
@@ -388,8 +399,8 @@ function jtls(
     end
     # Unpack
     Qtol, Mtol = params.lsQtol, params.lsMtol
-    @unpack jtlsorder, jtlsiter, outrej, jtlsmask, χ2_rec, χ2_rej,
-            fudge, max_per = params
+    @unpack jtlsorder, jtlsiter, outrej, jtlsmask, lspenalty, eph_su,
+            χ2_rec, χ2_rej, fudge, max_per = params
     @unpack orbits, res, Qs, q00s, outs, prbuffer, lscache, orcache = buffer
     # Reference epoch [Julian days TDB]
     jd0 = meanepoch(od) + PE.J2000
@@ -399,6 +410,7 @@ function jtls(
     # Least squares methods
     x0 = zeros(T, Npar)
     lsmethods = _lsmethods(res, x0, 1:Npar)
+    penalty = lspenalty ? zero(TaylorN{T}) : nothing
     # Initial subset of astrometry for orbit fit
     trksin, trksout, oidxs = _initialtracklets(od.tracklets, orbit.tracklets)
     radarin, radarout, ridxs = _initialradar(od, orbit)
@@ -415,7 +427,12 @@ function jtls(
         bwd, fwd = propres!(res, od, q0, jd0, params; buffer = prbuffer)
         any(isempty, res) && break
         # Orbit fit
-        fit = tryls((res[1][oidxs], res[2][ridxs]), x0, lscache, lsmethods; Qtol, Mtol)
+        if lspenalty
+            _q0_ = equatorial2ecliptic(q0 - eph_su(jd0 - PE.J2000))
+            e = eccentricity(_q0_..., μ_S, zero(T))
+            penalty = eccentricitypenalty(e)
+        end
+        fit = tryls((res[1][oidxs], res[2][ridxs]), x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break
         # Incrementally add observations to fit
         oidxs, ridxs, fit = addobservations!(od, oidxs, ridxs, fit, lscache, lsmethods,

--- a/src/orbitdetermination/jtls.jl
+++ b/src/orbitdetermination/jtls.jl
@@ -152,13 +152,18 @@ function addoptical!(
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         res::Vector{OpticalResidual{T, TaylorN{T}}},
         x0::Vector{T}, params::Parameters{T};
-        penalty::Union{Nothing, TaylorN{T}} = nothing
+        e::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
+    @unpack lspenalty = params
     Qtol, Mtol = params.lsQtol, params.lsMtol
+    penalty = lspenalty > 0 ? zero(TaylorN{T}) : nothing
     while !isempty(trksout)
         extra = indices(trksout[1])
-        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods;
-                        penalty, Qtol, Mtol)
+        subres = view(res, oidxs ∪ extra)
+        if lspenalty > 0
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
+        end
+        fit_new = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -178,13 +183,18 @@ function addoptical!(
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         res::Vector{OpticalResidual{T, TaylorN{T}}},
         x0::Vector{T}, params::Parameters{T};
-        penalty::Union{Nothing, TaylorN{T}} = nothing
+        e::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
+    @unpack lspenalty = params
     Qtol, Mtol = params.lsQtol, params.lsMtol
+    penalty = lspenalty > 0 ? zero(TaylorN{T}) : nothing
     if critical_value(view(res, oidxs), fit) < params.significance && !isempty(trksout)
         extra = indices(trksout[1])
-        fit_new = tryls(view(res, oidxs ∪ extra), x0, lscache, lsmethods;
-                        penalty, Qtol, Mtol)
+        subres = view(res, oidxs ∪ extra)
+        if lspenalty > 0
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
+        end
+        fit_new = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit_new) && return oidxs, fit
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -203,14 +213,19 @@ function addobservations!(
         trksin::TrackletVector{T}, trksout::TrackletVector{T},
         radarin::AbstractRadarVector{T}, radarout::AbstractRadarVector{T},
         res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T}, params::Parameters{T};
-        penalty::Union{Nothing, TaylorN{T}} = nothing
+        e::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
+    @unpack lspenalty = params
     Qtol, Mtol = params.lsQtol, params.lsMtol
+    penalty = lspenalty > 0 ? zero(TaylorN{T}) : nothing
     # Add optical astrometry
     while !isempty(trksout)
         extra = indices(trksout[1])
-        fit_new = tryls((res[1][oidxs ∪ extra], res[2][ridxs]), x0, lscache, lsmethods;
-                         penalty, Qtol, Mtol)
+        subres = (view(res[1], oidxs ∪ extra), view(res[2], ridxs))
+        if lspenalty > 0
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
+        end
+        fit_new = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         tracklet = popfirst!(trksout)
@@ -223,8 +238,11 @@ function addobservations!(
     while !isempty(radarout)
         extra = findfirst(==(radarout[1]), od.radar)
         isnothing(extra) && break
-        fit_new = tryls((res[1][oidxs], res[2][ridxs ∪ extra]), x0, lscache, lsmethods;
-                        penalty, Qtol, Mtol)
+        subres = (view(res[1], oidxs), voew(res[2], ridxs ∪ extra))
+        if lspenalty > 0
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
+        end
+        fit_new = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit_new) && break
         fit = fit_new
         radar = popfirst!(radarout)
@@ -330,7 +348,7 @@ function jtls(
     # Least squares methods
     x0 = zeros(T, Npar)
     lsmethods = _lsmethods(res, x0, 1:Npar)
-    penalty = lspenalty ? zero(TaylorN{T}) : nothing
+    e, penalty = lspenalty > 0 ? (zero(TaylorN{T}), zero(TaylorN{T})) : (nothing, nothing)
     # Initial subset of astrometry for orbit fit
     trksin, trksout, oidxs = _initialtracklets(od.tracklets, orbit.tracklets)
     # Jet Transport Least Squares
@@ -346,16 +364,17 @@ function jtls(
         bwd, fwd = propres!(res, od, q0, jd0, params; buffer = prbuffer)
         isempty(res) && break
         # Orbit fit
-        if lspenalty
+        subres = view(res, oidxs)
+        if lspenalty > 0
             _q0_ = equatorial2ecliptic(q0 - eph_su(jd0 - PE.J2000))
             e = eccentricity(_q0_..., μ_S, zero(T))
-            penalty = eccentricitypenalty(e)
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
         end
-        fit = tryls(view(res, oidxs), x0, lscache, lsmethods; penalty, Qtol, Mtol)
+        fit = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break
         # Incrementally add observations to fit
         oidxs, fit = addoptical!(Val(mode), oidxs, fit, lscache, lsmethods,
-                                 trksin, trksout, res, x0, params)
+                                 trksin, trksout, res, x0, params; e)
         fit.Γ .= project(q0[variables], fit)
         # Outlier rejection
         if outrej
@@ -410,7 +429,7 @@ function jtls(
     # Least squares methods
     x0 = zeros(T, Npar)
     lsmethods = _lsmethods(res, x0, 1:Npar)
-    penalty = lspenalty ? zero(TaylorN{T}) : nothing
+    e, penalty = lspenalty > 0 ? (zero(TaylorN{T}), zero(TaylorN{T})) : (nothing, nothing)
     # Initial subset of astrometry for orbit fit
     trksin, trksout, oidxs = _initialtracklets(od.tracklets, orbit.tracklets)
     radarin, radarout, ridxs = _initialradar(od, orbit)
@@ -427,16 +446,17 @@ function jtls(
         bwd, fwd = propres!(res, od, q0, jd0, params; buffer = prbuffer)
         any(isempty, res) && break
         # Orbit fit
-        if lspenalty
+        subres = (view(res[1], oidxs), view(res[2], ridxs))
+        if lspenalty > 0
             _q0_ = equatorial2ecliptic(q0 - eph_su(jd0 - PE.J2000))
             e = eccentricity(_q0_..., μ_S, zero(T))
-            penalty = eccentricitypenalty(e)
+            penalty = (lspenalty / notout(subres)) * eccentricitypenalty(e)
         end
-        fit = tryls((res[1][oidxs], res[2][ridxs]), x0, lscache, lsmethods; penalty, Qtol, Mtol)
+        fit = tryls(subres, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break
         # Incrementally add observations to fit
         oidxs, ridxs, fit = addobservations!(od, oidxs, ridxs, fit, lscache, lsmethods,
-            trksin, trksout, radarin, radarout, res, x0, params)
+            trksin, trksout, radarin, radarout, res, x0, params; e)
         fit.Γ .= project(q0[variables], fit)
         # Outlier rejection
         if outrej

--- a/src/orbitdetermination/leastsquares/methods.jl
+++ b/src/orbitdetermination/leastsquares/methods.jl
@@ -33,7 +33,7 @@ of the parameters.
 
 - `maxiter::Int`: maximum number of iterations (default: `25`)
 """
-function LeastSquaresCache(x0::Vector{T}, idxs::AbstractVector{Int} = eachindex(x0),
+function LeastSquaresCache(x0::AbstractVector{T}, idxs::AbstractVector{Int} = eachindex(x0),
     maxiter::Int = 25) where {T <: Real}
     xs = Matrix{T}(undef, length(x0), maxiter + 1)
     Qs = Vector{T}(undef, maxiter + 1)
@@ -118,20 +118,26 @@ set of O-C residuals `res`, starting from initial guess `x0`. If `idxs`
 (default: `eachindex(x0)`) is given, perform the minimization over a
 subset of the parameters.
 
-# Keyword argument
+# Keyword arguments
 
+- `penalty::Union{Nothing, TaylorN{<:Real}}`: penalty term for target
+    function (default: `nothing`).
 - `maxiter::Int`: maximum number of iterations (default: `25`).
 - `Qtol::Real`: target function absolute tolerance (default: `1E-3`).
 - `Mtol::Real`: Mahalanobis distance tolerance (default: `1E-3`).
 """
-function leastsquares(method::Type{<:AbstractLeastSquaresMethod{T}},
-                      res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T},
-                      idxs::AbstractVector{Int} = eachindex(x0); maxiter::Int = 25,
-                      Qtol::T = 1E-3, Mtol::T = 1E-3) where {T <: Real}
+function leastsquares(
+        method::Type{<:AbstractLeastSquaresMethod{T}},
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing,
+        maxiter::Int = 25, Qtol::T = 1E-3, Mtol::T = 1E-3
+    ) where {T <: Real}
     # Consistency checks
     @assert length(idxs) ≤ length(x0) == get_numvars()
     # Initialize least squares method and cache
-    ls = method(res, x0, idxs)
+    ls = method(res, x0, idxs; penalty)
     cache = LeastSquaresCache(x0, idxs, maxiter)
     # Main loop
     fit = leastsquares!(ls, cache; Qtol, Mtol)
@@ -139,13 +145,19 @@ function leastsquares(method::Type{<:AbstractLeastSquaresMethod{T}},
 end
 
 """
-    Newton(res, x0 [, idxs])
+    Newton(res, x0 [, idxs]; kwargs...)
 
-Newton method for minimizing the normalized mean square of a set of O-C residuals
-`res`, starting from initial guess `x0`. If `idxs` (default: `eachindex(x0)`) is
-given, perform the minimization over a subset of the parameters.
+Newton method for minimizing the normalized mean square of a set of
+O-C residuals `res`, starting from initial guess `x0`. If `idxs`
+(default: `eachindex(x0)`) is given, perform the minimization
+over a subset of the parameters.
 
 See also [`leastsquares`](@ref).
+
+# Keyword arguments
+
+- `penalty::Union{Nothing, TaylorN{<:Real}}`: penalty term for target
+    function (default: `nothing`).
 
 !!! reference
     See sections 5.2 and 5.3 of:
@@ -164,12 +176,19 @@ end
 getid(::Newton) = "Newton"
 targetfunction(x::Newton) = x.Q
 
-function Newton(res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T},
-                idxs::AbstractVector{Int} = eachindex(x0)) where {T <: Real}
+function Newton(
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     nobs, npar = notoutobs(res), length(idxs)
     # Mean square residual and its gradient
     Q = nms(res)
+    if !isnothing(penalty)
+        Q += penalty
+    end
     GQ = TaylorSeries.gradient(Q)[idxs]
     # Hessian of the target function
     HQ = [zero(Q) for _ in 1:npar, _ in 1:npar]
@@ -210,12 +229,18 @@ function normalmatrix(ls::Newton, x::AbstractVector)
     return (nobs / 2) * d2Q
 end
 
-function update!(ls::Newton{T}, res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T},
-                 idxs::AbstractVector{Int}) where {T <: Real}
+function update!(
+        ls::Newton{T}, res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T}, idxs::AbstractVector{Int};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     ls.nobs, ls.npar = notoutobs(res), length(idxs)
     # Mean square residual and its gradient
     ls.Q = nms(res)
+    if !isnothing(penalty)
+        ls.Q += penalty
+    end
     TS.zero!.(ls.GQ)
     ls.GQ .= TaylorSeries.gradient(ls.Q)[idxs]
     # Hessian
@@ -233,13 +258,19 @@ function update!(ls::Newton{T}, res::AbstractResidualSet{T, TaylorN{T}}, x0::Vec
 end
 
 """
-    DifferentialCorrections(res, x0 [, idxs])
+    DifferentialCorrections(res, x0 [, idxs]; kwargs...)
 
-Differential corrections method for minimizing the normalized mean square of a
-set of O-C residuals `res`, starting from initial guess `x0`. If `idxs` (default:
-`eachindex(x0)`) is given, perform the minimization over a subset of the parameters.
+Differential corrections method for minimizing the normalized mean
+square of a set of O-C residuals `res`, starting from initial guess
+`x0`. If `idxs` (default: `eachindex(x0)`) is given, perform the
+minimization over a subset of the parameters.
 
 See also [`leastsquares`](@ref).
+
+# Keyword arguments
+
+- `penalty::Union{Nothing, TaylorN{<:Real}}`: penalty term for target
+    function (default: `nothing`).
 
 !!! reference
     See sections 5.2 and 5.3 of:
@@ -258,12 +289,19 @@ end
 getid(::DifferentialCorrections) = "Differential Corrections"
 targetfunction(x::DifferentialCorrections) = x.Q
 
-function DifferentialCorrections(res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T},
-                                 idxs::AbstractVector{Int} = eachindex(x0)) where {T <: Real}
+function DifferentialCorrections(
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     nobs, npar = notoutobs(res), length(idxs)
     # Mean square residual and its gradient
     Q = nms(res)
+    if !isnothing(penalty)
+        Q += penalty
+    end
     # D matrix and normal matrix C
     D, C, _, _ = DCVB(res, idxs)
     # Deprecated term
@@ -298,12 +336,18 @@ function normalmatrix(ls::DifferentialCorrections, x::AbstractVector)
     return Cx
 end
 
-function update!(ls::DifferentialCorrections{T}, res::AbstractResidualSet{T, TaylorN{T}},
-                 x0::Vector{T}, idxs::AbstractVector{Int}) where {T <: Real}
+function update!(
+        ls::DifferentialCorrections{T}, res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T}, idxs::AbstractVector{Int};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     ls.nobs, ls.npar = notoutobs(res), length(idxs)
     # Mean square residual and its gradient
     ls.Q = nms(res)
+    if !isnothing(penalty)
+        ls.Q += penalty
+    end
     # D matrix and normal matrix C
     ls.D, ls.C, _, _ = DCVB(res, idxs)
     # Deprecated term
@@ -377,14 +421,19 @@ function ξTH(res::AbstractResidualSet{T, TaylorN{T}}, V::AbstractVector{TaylorN
 end
 
 """
-    LevenbergMarquardt(res, x0 [, idxs])
+    LevenbergMarquardt(res, x0 [, idxs]; kwargs...)
 
-Levenberg-Marquardt method for minimizing the normalized mean square of a
-set of O-C residuals `res`, starting from initial guess `x0`. If `idxs`
-(default: `eachindex(x0)`) is given, perform the minimization over a subset
-of the parameters.
+Levenberg-Marquardt method for minimizing the normalized mean square
+of a set of O-C residuals `res`, starting from initial guess `x0`. If
+`idxs` (default: `eachindex(x0)`) is given, perform the minimization
+over a subset of the parameters.
 
 See also [`leastsquares`](@ref).
+
+# Keyword arguments
+
+- `penalty::Union{Nothing, TaylorN{<:Real}}`: penalty term for target
+    function (default: `nothing`).
 
 !!! reference
     See section 15.5.2 of:
@@ -406,14 +455,21 @@ getid(::LevenbergMarquardt) = "Levenberg-Marquardt"
 targetfunction(x::LevenbergMarquardt) = x.Q
 isrejected(::LevenbergMarquardt, Δx) = iszero(Δx)
 
-function LevenbergMarquardt(res::AbstractResidualSet{T, TaylorN{T}}, x0::Vector{T},
-                            idxs::AbstractVector{Int} = eachindex(x0)) where {T <: Real}
+function LevenbergMarquardt(
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     nobs, npar = notoutobs(res), length(idxs)
     # Damping factor
     λ = T(0.001)
     # Mean square residual and its gradient
     Q = nms(res)
+    if !isnothing(penalty)
+        Q += penalty
+    end
     GQ = TaylorSeries.gradient(Q)[idxs]
     # Hessian
     HQ = [zero(Q) for _ in 1:npar, _ in 1:npar]
@@ -463,14 +519,20 @@ function normalmatrix(ls::LevenbergMarquardt, x::AbstractVector)
     return (nobs / 2) * d2Q
 end
 
-function update!(ls::LevenbergMarquardt{T}, res::AbstractResidualSet{T, TaylorN{T}},
-                 x0::Vector{T}, idxs::AbstractVector{Int}) where {T <: Real}
+function update!(
+        ls::LevenbergMarquardt{T}, res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T}, idxs::AbstractVector{Int};
+        penalty::Union{Nothing, TaylorN{T}} = nothing
+    ) where {T <: Real}
     # Number of observations and degrees of freedom
     ls.nobs, ls.npar = notoutobs(res), length(idxs)
     # Damping factor
     ls.λ = T(0.001)
     # Mean square residual and its gradient
     ls.Q = nms(res)
+    if !isnothing(penalty)
+        ls.Q += penalty
+    end
     TS.zero!.(ls.GQ)
     ls.GQ .= TaylorSeries.gradient(ls.Q)[idxs]
     # Hessian
@@ -489,13 +551,15 @@ end
 
 # Default methods for tryls
 function _lsmethods(
-        res::AbstractResidualSet{T, TaylorN{T}}, x0::AbstractVector{T},
-        idxs::AbstractVector{Int} = eachindex(x0)
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing
     ) where {T <: Real}
     return (
-        Newton(res, x0, idxs),
-        DifferentialCorrections(res, x0, idxs),
-        LevenbergMarquardt(res, x0, idxs)
+        Newton(res, x0, idxs; penalty),
+        DifferentialCorrections(res, x0, idxs; penalty),
+        LevenbergMarquardt(res, x0, idxs; penalty)
     )
 end
 
@@ -503,14 +567,14 @@ end
 _tryls(fit, res, x0, cache, methods::Tuple{}; kwargs...) = fit
 
 # Recursive step
-function _tryls(fit, res, x0, cache, methods::Tuple; kwargs...)
+function _tryls(fit, res, x0, cache, methods::Tuple; penalty, kwargs...)
     method = first(methods)
-    update!(method, res, x0, cache.idxs)
+    update!(method, res, x0, cache.idxs; penalty)
     newfit = leastsquares!(method, cache; kwargs...)
     if issuccess(newfit) && 0 < targetfunction(method, newfit) < targetfunction(method, fit)
         fit = newfit
     end
-    return _tryls(fit, res, x0, cache, Base.tail(methods); kwargs...)
+    return _tryls(fit, res, x0, cache, Base.tail(methods); penalty, kwargs...)
 end
 
 # Main entry point
@@ -531,18 +595,22 @@ subset of the parameters.
 See also [`LeastSquaresCache`](@ref), [`AbstractLeastSquaresMethod`](@ref),
 [`_lsmethods`](@ref) and [`leastsquares!`](@ref).
 
-# Keyword Argument
+# Keyword arguments
 
+- `penalty::Union{Nothing, TaylorN{<:Real}}`: penalty term for target
+    function (default: `nothing`).
 - `maxiter::Int`: maximum number of iterations (default: `25`).
 - `Qtol::Real`: target function absolute tolerance (default: `1E-3`).
 - `Mtol::Real`: Mahalanobis distance tolerance (default: `1E-3`).
 """
 function tryls(
-        res::AbstractResidualSet{T, TaylorN{T}}, x0::AbstractVector{T},
-        idxs::AbstractVector{Int} = eachindex(x0); maxiter::Int = 25,
-        Qtol::T = 1E-3, Mtol::T = 1E-3
+        res::AbstractResidualSet{T, TaylorN{T}},
+        x0::AbstractVector{T},
+        idxs::AbstractVector{Int} = eachindex(x0);
+        penalty::Union{Nothing, TaylorN{T}} = nothing,
+        maxiter::Int = 25, Qtol::T = 1E-3, Mtol::T = 1E-3,
     ) where {T <: Real}
     cache = LeastSquaresCache(x0, idxs, maxiter)
-    methods = _lsmethods(res, x0, idxs)
-    return tryls(res, x0, cache, methods; Qtol, Mtol)
+    methods = _lsmethods(res, x0, idxs; penalty)
+    return tryls(res, x0, cache, methods; penalty, Qtol, Mtol)
 end

--- a/src/orbitdetermination/orbitdetermination.jl
+++ b/src/orbitdetermination/orbitdetermination.jl
@@ -30,6 +30,15 @@ function iodinitcond(A::AdmissibleRegion)
     ]
 end
 
+"""
+    eccentricitypenalty(::Number)
+
+Penalty term corresponding to the natural logarithm of the
+Rayleigh distribution of the eccentricities of all asteroids
+recognized by the MPC by September 2, 2026.
+"""
+eccentricitypenalty(e::Number) = e^2 / (2ECCENTRICITY_RAYLEIGH_SIGMA^2) - log(e)
+
 #=
 """
     issinglearc(::AbstractOpticalVector, arc::Day)

--- a/src/orbitdetermination/preliminary/gauss.jl
+++ b/src/orbitdetermination/preliminary/gauss.jl
@@ -338,7 +338,7 @@ function gaussiod(od::OpticalODProblem{D, T, O}, params::Parameters{T}) where {D
     # Filter preliminary orbits
     filter!(!iszero, porbits)
     filter!(isphysical, porbits)
-    filter!(isclosed, porbits)
+    # filter!(isclosed, porbits)
     # Iterate over remaining preliminary orbits
     for i in eachindex(porbits)
         # Jet Transport Least Squares

--- a/src/orbitdetermination/preliminary/mmov.jl
+++ b/src/orbitdetermination/preliminary/mmov.jl
@@ -63,7 +63,7 @@ function mmov(od::OpticalODProblem{D, T, O}, A::AdmissibleRegion{T}, ρ::T, v_ρ
     # Least squares cache and methods
     lscache = LeastSquaresCache(x0, 1:4, 5)
     lsmethods = _lsmethods(res, x0, 1:4)
-    penalty = lspenalty ? zero(TaylorN{T}) : nothing
+    penalty = lspenalty > 0 ? zero(TaylorN{T}) : nothing
     # Gradient of objective function wrt (ρ, v_ρ)
     g_t = zeros(T, 2)
     # First and second momentum
@@ -93,10 +93,10 @@ function mmov(od::OpticalODProblem{D, T, O}, A::AdmissibleRegion{T}, ρ::T, v_ρ
         bwd, fwd = propres!(res, od, q, jd0, params; buffer, idxs)
         isempty(res) && break
         # Least squares fit
-        if lspenalty
+        if lspenalty > 0
             _q0_ = equatorial2ecliptic(q - eph_su(jd0 - PE.J2000))
             e = eccentricity(_q0_..., μ_S, zero(T))
-            penalty = eccentricitypenalty(e)
+            penalty = (lspenalty / notout(res)) * eccentricitypenalty(e)
         end
         fit = tryls(res, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break

--- a/src/orbitdetermination/preliminary/mmov.jl
+++ b/src/orbitdetermination/preliminary/mmov.jl
@@ -27,11 +27,12 @@ function mmov(od::OpticalODProblem{D, T, O}, A::AdmissibleRegion{T}, ρ::T, v_ρ
               T <: Real, O <: AbstractOpticalVector{T}}
     # Unpack
     Qtol, Mtol = params.lsQtol, params.lsMtol
-    @unpack adamiter, adammode, adamQtol, mmovproject, significance = params
+    @unpack eph_su, adamiter, adammode, adamQtol, lspenalty, mmovproject,
+            significance = params
     @unpack dynamics = od
     variables = collect(1:6)
     # Initial time of integration [julian days TDB]
-    jd0 = dtutc2jdtdb(A.date)
+    _jd0_ = dtutc2jdtdb(A.date)
     # Pre-allocate memory
     aes = Matrix{T}(undef, 6, adamiter+1)
     Qs = fill(T(Inf), adamiter+1)
@@ -55,13 +56,14 @@ function mmov(od::OpticalODProblem{D, T, O}, A::AdmissibleRegion{T}, ρ::T, v_ρ
     idxs = indices(tracklets)
     optical = od.optical[idxs]
     # Initialize buffer and set of residuals
-    buffer = PropresBuffer(od, AE, jd0, idxs, params)
+    buffer = PropresBuffer(od, AE, _jd0_, idxs, params)
     res = init_optical_residuals(TaylorN{T}, od, idxs)
     # Origin
     x0, x1 = zeros(T, 6), zeros(T, 6)
     # Least squares cache and methods
     lscache = LeastSquaresCache(x0, 1:4, 5)
     lsmethods = _lsmethods(res, x0, 1:4)
+    penalty = lspenalty ? zero(TaylorN{T}) : nothing
     # Gradient of objective function wrt (ρ, v_ρ)
     g_t = zeros(T, 2)
     # First and second momentum
@@ -87,10 +89,16 @@ function mmov(od::OpticalODProblem{D, T, O}, A::AdmissibleRegion{T}, ρ::T, v_ρ
         # Propagation and residuals
         # TO DO: `ρ::TaylorN` is too slow for `mmov` due to evaluations
         # within the dynamical model
-        bwd, fwd = propres!(res, od, q, jd0 - ae[5]/c_au_per_day, params; buffer, idxs)
+        jd0 = _jd0_ - ae[5]/c_au_per_day
+        bwd, fwd = propres!(res, od, q, jd0, params; buffer, idxs)
         isempty(res) && break
         # Least squares fit
-        fit = tryls(res, x0, lscache, lsmethods; Qtol, Mtol)
+        if lspenalty
+            _q0_ = equatorial2ecliptic(q - eph_su(jd0 - PE.J2000))
+            e = eccentricity(_q0_..., μ_S, zero(T))
+            penalty = eccentricitypenalty(e)
+        end
+        fit = tryls(res, x0, lscache, lsmethods; penalty, Qtol, Mtol)
         !issuccess(fit) && break
         x1 .= fit.x
         # Current Q

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -57,8 +57,7 @@ nongravitational accelerations model:
 
 # Least Squares
 
-- `lspenalty::Bool`: whether to add a penalty to the orbit's eccentricity to
-    the target function (default: `false`).
+- `lspenalty::T`: scaling parameter for the eccentricity penalty (default: `0`).
 - `lsiter::Int`: maximum number of iterations for `leastsquares` (default: `10`).
 - `lsQtol::T`: target function absolute tolerance (default: `1E-3`).
 - `lsMtol::T`: Mahalanobis distance tolerance (default: `1E-3`).
@@ -121,7 +120,7 @@ nongravitational accelerations model:
     mmovproject::Bool = true
     tsaorder::Int = 6
     # Least Squares
-    lspenalty::Bool = false
+    lspenalty::T = 0.0
     lsiter::Int = 10
     lsQtol::T = 1E-3
     lsMtol::T = 1E-3

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -57,6 +57,8 @@ nongravitational accelerations model:
 
 # Least Squares
 
+- `lspenalty::Bool`: whether to add a penalty to the orbit's eccentricity to
+    the target function (default: `false`).
 - `lsiter::Int`: maximum number of iterations for `leastsquares` (default: `10`).
 - `lsQtol::T`: target function absolute tolerance (default: `1E-3`).
 - `lsMtol::T`: Mahalanobis distance tolerance (default: `1E-3`).
@@ -119,6 +121,7 @@ nongravitational accelerations model:
     mmovproject::Bool = true
     tsaorder::Int = 6
     # Least Squares
+    lspenalty::Bool = false
     lsiter::Int = 10
     lsQtol::T = 1E-3
     lsMtol::T = 1E-3


### PR DESCRIPTION
This PR gives the user the possibility of adding a penalty term to the target function during the least squares procedure. For now, the high-level orbit determination interface can only add a penalty corresponding the logarithm of the Rayleigh distribution of the eccentricities of all asteroids recognized by the MPC  by September 2, 2026.